### PR TITLE
feat(healthz): basic healthz handler implementation

### DIFF
--- a/handlers/healthz.go
+++ b/handlers/healthz.go
@@ -1,0 +1,12 @@
+package handlers
+
+import (
+	"github.com/go-swagger/go-swagger/httpkit/middleware"
+	"github.com/helm/monocular/pkg/swagger/restapi/operations"
+)
+
+// Healthz is the handler for the /healthz endpoint
+func Healthz() middleware.Responder {
+	//TODO implement actual health check business logic
+	return operations.NewHealthzOK()
+}

--- a/pkg/swagger/restapi/configure_monocular.go
+++ b/pkg/swagger/restapi/configure_monocular.go
@@ -7,6 +7,7 @@ import (
 	httpkit "github.com/go-swagger/go-swagger/httpkit"
 	middleware "github.com/go-swagger/go-swagger/httpkit/middleware"
 
+	"github.com/helm/monocular/handlers"
 	"github.com/helm/monocular/pkg/swagger/restapi/operations"
 )
 
@@ -25,7 +26,7 @@ func configureAPI(api *operations.MonocularAPI) http.Handler {
 	api.JSONProducer = httpkit.JSONProducer()
 
 	api.HealthzHandler = operations.HealthzHandlerFunc(func() middleware.Responder {
-		return middleware.NotImplemented("operation .Healthz has not yet been implemented")
+		return handlers.Healthz()
 	})
 
 	api.ServerShutdown = func() {}


### PR DESCRIPTION
This includes an example handler implementation of our initial `GET /healthz` API endpoint. I intentionally did this as a separate PR to demonstrate some of the flow of swagger-generated dev.