### PR TITLE
tests(restapi): added test coverage to swagger-generated API server

### DIFF
--- a/src/api/data/charts_test.go
+++ b/src/api/data/charts_test.go
@@ -4,18 +4,14 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-)
-
-const (
-	repoName  = "stable"
-	chartName = "apache"
+	"github.com/helm/monocular/src/api/pkg/testutil"
 )
 
 func TestGetChart(t *testing.T) {
-	chart, err := GetChart(repoName, chartName)
+	chart, err := GetChart(testutil.RepoName, testutil.ChartName)
 	assert.NoErr(t, err)
-	assert.Equal(t, *chart.ID, repoName+"/"+chartName, "chart ID")
-	chart, err = GetChart("bogon", chartName)
+	assert.Equal(t, *chart.ID, testutil.RepoName+"/"+testutil.ChartName, "chart ID")
+	chart, err = GetChart(testutil.BogusRepo, testutil.ChartName)
 	assert.ExistsErr(t, err, "sent bogus repo name to GetChart")
 	assert.Nil(t, chart.ID, "zero value ID")
 }
@@ -26,7 +22,7 @@ func TestGetAllCharts(t *testing.T) {
 }
 
 func TestGetChartsInRepo(t *testing.T) {
-	charts, err := GetChartsInRepo(repoName)
+	charts, err := GetChartsInRepo(testutil.RepoName)
 	assert.NoErr(t, err)
 	assert.True(t, len(charts) > 0, "returned charts")
 	noCharts, err := GetChartsInRepo("bogon")

--- a/src/api/handlers/charts_test.go
+++ b/src/api/handlers/charts_test.go
@@ -11,42 +11,37 @@ import (
 	"github.com/helm/monocular/src/api/mocks"
 	"github.com/helm/monocular/src/api/pkg/swagger/models"
 	"github.com/helm/monocular/src/api/pkg/swagger/restapi/operations"
-)
-
-const (
-	repoName  = "stable"
-	bogusRepo = "bogon"
-	chartName = "apache"
+	"github.com/helm/monocular/src/api/pkg/testutil"
 )
 
 func TestGetChart200(t *testing.T) {
-	chart, err := data.GetChart(repoName, chartName)
+	chart, err := data.GetChart(testutil.RepoName, testutil.ChartName)
 	assert.NoErr(t, err)
 	w := httptest.NewRecorder()
 	params := operations.GetChartParams{
-		Repo:      repoName,
-		ChartName: chartName,
+		Repo:      testutil.RepoName,
+		ChartName: testutil.ChartName,
 	}
 	resp := GetChart(params)
 	assert.NotNil(t, resp, "GetChart response")
 	resp.WriteResponse(w, runtime.JSONProducer())
 	assert.Equal(t, w.Code, http.StatusOK, "expect a 200 response code")
 	var httpBody models.ResourceData
-	assert.NoErr(t, ResourceDataFromJSON(w.Body, &httpBody))
+	assert.NoErr(t, testutil.ResourceDataFromJSON(w.Body, &httpBody))
 	AssertChartResourceBodyData(t, chart, httpBody)
 }
 
 func TestGetChart404(t *testing.T) {
 	w := httptest.NewRecorder()
 	bogonParams := operations.GetChartParams{
-		Repo:      bogusRepo,
-		ChartName: chartName,
+		Repo:      testutil.BogusRepo,
+		ChartName: testutil.ChartName,
 	}
 	errResp := GetChart(bogonParams)
 	errResp.WriteResponse(w, runtime.JSONProducer())
 	assert.Equal(t, w.Code, http.StatusNotFound, "expect a 404 response code")
 	var httpBody models.Error
-	assert.NoErr(t, ErrorModelFromJSON(w.Body, &httpBody))
+	assert.NoErr(t, testutil.ErrorModelFromJSON(w.Body, &httpBody))
 	AssertErrBodyData(t, http.StatusNotFound, "chart", httpBody)
 }
 
@@ -60,23 +55,23 @@ func TestGetAllCharts200(t *testing.T) {
 	resp.WriteResponse(w, runtime.JSONProducer())
 	assert.Equal(t, w.Code, http.StatusOK, "expect a 200 response code")
 	var httpBody models.ResourceArrayData
-	assert.NoErr(t, ResourceArrayDataFromJSON(w.Body, &httpBody))
+	assert.NoErr(t, testutil.ResourceArrayDataFromJSON(w.Body, &httpBody))
 	assert.Equal(t, len(charts), len(httpBody.Data), "number of charts returned")
 }
 
 func TestGetChartsInRepo200(t *testing.T) {
-	charts, err := data.GetChartsInRepo(repoName)
+	charts, err := data.GetChartsInRepo(testutil.RepoName)
 	assert.NoErr(t, err)
 	w := httptest.NewRecorder()
 	params := operations.GetChartsInRepoParams{
-		Repo: repoName,
+		Repo: testutil.RepoName,
 	}
 	resp := GetChartsInRepo(params)
 	assert.NotNil(t, resp, "GetChartsInRepo response")
 	resp.WriteResponse(w, runtime.JSONProducer())
 	assert.Equal(t, w.Code, http.StatusOK, "expect a 200 response code")
 	var httpBody models.ResourceArrayData
-	assert.NoErr(t, ResourceArrayDataFromJSON(w.Body, &httpBody))
+	assert.NoErr(t, testutil.ResourceArrayDataFromJSON(w.Body, &httpBody))
 	assert.Equal(t, len(charts), len(httpBody.Data), "number of charts returned")
 }
 
@@ -90,20 +85,20 @@ func TestGetChartsInRepo404(t *testing.T) {
 	resp.WriteResponse(w, runtime.JSONProducer())
 	assert.Equal(t, w.Code, http.StatusNotFound, "expect a 404 response code")
 	var httpBody models.Error
-	assert.NoErr(t, ErrorModelFromJSON(w.Body, &httpBody))
+	assert.NoErr(t, testutil.ErrorModelFromJSON(w.Body, &httpBody))
 	AssertErrBodyData(t, http.StatusNotFound, "charts", httpBody)
 }
 
 func TestChartHTTPBody(t *testing.T) {
 	w := httptest.NewRecorder()
-	chart, err := mocks.GetChartFromMockRepo(repoName, chartName)
+	chart, err := mocks.GetChartFromMockRepo(testutil.RepoName, testutil.ChartName)
 	assert.NoErr(t, err)
 	resp := chartHTTPBody(chart)
 	assert.NotNil(t, resp, "chartHTTPBody response")
 	resp.WriteResponse(w, runtime.JSONProducer())
 	assert.Equal(t, w.Code, http.StatusOK, "expect a 200 response code")
 	var httpBody models.ResourceData
-	assert.NoErr(t, ResourceDataFromJSON(w.Body, &httpBody))
+	assert.NoErr(t, testutil.ResourceDataFromJSON(w.Body, &httpBody))
 	AssertChartResourceBodyData(t, chart, httpBody)
 }
 
@@ -116,6 +111,6 @@ func TestChartsHTTPBody(t *testing.T) {
 	resp.WriteResponse(w, runtime.JSONProducer())
 	assert.Equal(t, w.Code, http.StatusOK, "expect a 200 response code")
 	var httpBody models.ResourceArrayData
-	assert.NoErr(t, ResourceArrayDataFromJSON(w.Body, &httpBody))
+	assert.NoErr(t, testutil.ResourceArrayDataFromJSON(w.Body, &httpBody))
 	assert.Equal(t, len(charts), len(httpBody.Data), "number of charts returned")
 }

--- a/src/api/mocks/charts_test.go
+++ b/src/api/mocks/charts_test.go
@@ -4,18 +4,14 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
-)
-
-const (
-	repoName  = "stable"
-	chartName = "apache"
+	"github.com/helm/monocular/src/api/pkg/testutil"
 )
 
 func TestGetChartFromMockRepo(t *testing.T) {
-	chart, err := GetChartFromMockRepo(repoName, chartName)
+	chart, err := GetChartFromMockRepo(testutil.RepoName, testutil.ChartName)
 	assert.NoErr(t, err)
-	assert.Equal(t, *chart.ID, repoName+"/"+chartName, "chart ID")
-	chart, err = GetChartFromMockRepo("bogon", chartName)
+	assert.Equal(t, *chart.ID, testutil.RepoName+"/"+testutil.ChartName, "chart ID")
+	chart, err = GetChartFromMockRepo("bogon", testutil.ChartName)
 	assert.ExistsErr(t, err, "sent bogus repo name to GetChartFromMockRepo")
 	assert.Nil(t, chart.ID, "zero value ID")
 }
@@ -27,7 +23,7 @@ func TestGetAllChartsFromMockRepos(t *testing.T) {
 }
 
 func TestGetChartsFromMockRepo(t *testing.T) {
-	charts, err := GetChartsFromMockRepo(repoName)
+	charts, err := GetChartsFromMockRepo(testutil.RepoName)
 	assert.NoErr(t, err)
 	assert.True(t, len(charts) > 0, "at least 1 chart returned")
 	charts, err = GetChartsFromMockRepo("unparseable")

--- a/src/api/mocks/mocks_test.go
+++ b/src/api/mocks/mocks_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 
 	"github.com/arschles/assert"
+	"github.com/helm/monocular/src/api/pkg/testutil"
 )
 
 func TestGetYAML(t *testing.T) {
 	path, err := getTestDataWd()
 	assert.NoErr(t, err)
-	path += fmt.Sprintf("repo-%s.yaml", repoName)
+	path += fmt.Sprintf("repo-%s.yaml", testutil.RepoName)
 	_, err = getYAML(path)
 	assert.NoErr(t, err)
 	path, err = getTestDataWd()

--- a/src/api/pkg/swagger/restapi/server_test.go
+++ b/src/api/pkg/swagger/restapi/server_test.go
@@ -1,0 +1,121 @@
+package restapi
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/arschles/assert"
+	"github.com/go-openapi/loads"
+	"github.com/helm/monocular/src/api/data"
+	"github.com/helm/monocular/src/api/pkg/swagger/models"
+	"github.com/helm/monocular/src/api/pkg/swagger/restapi/operations"
+	"github.com/helm/monocular/src/api/pkg/testutil"
+)
+
+// tests the GET /healthz endpoint
+func TestGetHealthz(t *testing.T) {
+	srv, err := newServer()
+	assert.NoErr(t, err)
+	defer srv.Close()
+	resp, err := httpGet(srv, "healthz")
+	assert.NoErr(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, resp.StatusCode, http.StatusOK, "response code")
+}
+
+// tests the GET /{:apiVersion}/charts endpoint
+func TestGetCharts(t *testing.T) {
+	srv, err := newServer()
+	assert.NoErr(t, err)
+	defer srv.Close()
+	charts, err := data.GetAllCharts()
+	assert.NoErr(t, err)
+	resp, err := httpGet(srv, urlPath("v1", "charts"))
+	assert.NoErr(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, resp.StatusCode, http.StatusOK, "response code")
+	var httpBody models.ResourceArrayData
+	assert.NoErr(t, testutil.ResourceArrayDataFromJSON(resp.Body, &httpBody))
+	assert.Equal(t, len(charts), len(httpBody.Data), "number of charts returned")
+}
+
+// tests the GET /{:apiVersion}/charts/{:repo} endpoint 200 response
+func TestGetChartsInRepo200(t *testing.T) {
+	srv, err := newServer()
+	assert.NoErr(t, err)
+	defer srv.Close()
+	charts, err := data.GetChartsInRepo(testutil.RepoName)
+	assert.NoErr(t, err)
+	resp, err := httpGet(srv, urlPath("v1", "charts", testutil.RepoName))
+	assert.NoErr(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, resp.StatusCode, http.StatusOK, "response code")
+	var httpBody models.ResourceArrayData
+	assert.NoErr(t, testutil.ResourceArrayDataFromJSON(resp.Body, &httpBody))
+	assert.Equal(t, len(charts), len(httpBody.Data), "number of charts returned")
+}
+
+// tests the GET /{:apiVersion}/charts/{:repo} endpoint 404 response
+func TestGetChartsInRepo404(t *testing.T) {
+	srv, err := newServer()
+	assert.NoErr(t, err)
+	defer srv.Close()
+	resp, err := httpGet(srv, urlPath("v1", "charts", testutil.BogusRepo))
+	assert.NoErr(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, resp.StatusCode, http.StatusNotFound, "response code")
+	var httpBody models.Error
+	assert.NoErr(t, testutil.ErrorModelFromJSON(resp.Body, &httpBody))
+	testutil.AssertErrBodyData(t, http.StatusNotFound, "charts", httpBody)
+}
+
+// tests the GET /{:apiVersion}/charts/{:repo}/{:chart} endpoint 200 response
+func TestGetChartInRepo200(t *testing.T) {
+	srv, err := newServer()
+	assert.NoErr(t, err)
+	defer srv.Close()
+	chart, err := data.GetChart(testutil.RepoName, testutil.ChartName)
+	assert.NoErr(t, err)
+	resp, err := httpGet(srv, urlPath("v1", "charts", testutil.RepoName, testutil.ChartName))
+	assert.NoErr(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, resp.StatusCode, http.StatusOK, "response code")
+	var httpBody models.ResourceData
+	assert.NoErr(t, testutil.ResourceDataFromJSON(resp.Body, &httpBody))
+	testutil.AssertChartResourceBodyData(t, chart, httpBody)
+}
+
+// tests the GET /{:apiVersion}/charts/{:repo}/{:chart} endpoint 404 response
+func TestGetChartInRepo404(t *testing.T) {
+	srv, err := newServer()
+	assert.NoErr(t, err)
+	defer srv.Close()
+	resp, err := httpGet(srv, urlPath("v1", "charts", testutil.BogusRepo, testutil.ChartName))
+	assert.NoErr(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, resp.StatusCode, http.StatusNotFound, "response code")
+	var httpBody models.Error
+	assert.NoErr(t, testutil.ErrorModelFromJSON(resp.Body, &httpBody))
+	testutil.AssertErrBodyData(t, http.StatusNotFound, "chart", httpBody)
+}
+
+func newServer() (*httptest.Server, error) {
+	swaggerSpec, err := loads.Analyzed(SwaggerJSON, "")
+	if err != nil {
+		return nil, err
+	}
+	api := operations.NewMonocularAPI(swaggerSpec)
+	return httptest.NewServer(configureAPI(api)), nil
+}
+
+func urlPath(ver string, remainder ...string) string {
+	return fmt.Sprintf("%s/%s", ver, strings.Join(remainder, "/"))
+}
+
+func httpGet(s *httptest.Server, route string) (*http.Response, error) {
+	fmt.Println(s.URL + "/" + route)
+	return http.Get(s.URL + "/" + route)
+}

--- a/src/api/pkg/testutil/testutil.go
+++ b/src/api/pkg/testutil/testutil.go
@@ -1,0 +1,79 @@
+package testutil
+
+import (
+	"encoding/json"
+	"io"
+	"strconv"
+	"testing"
+
+	"github.com/arschles/assert"
+	"github.com/helm/monocular/src/api/pkg/swagger/models"
+)
+
+// constants
+const (
+	RepoName  = "stable"
+	BogusRepo = "bogon"
+	ChartName = "apache"
+)
+
+// AssertErrBodyData asserts expected HTTP error response body data
+func AssertErrBodyData(t *testing.T, code int64, resource string, body models.Error) {
+	assert.Equal(t, *body.Code, code, "response code in HTTP body data")
+	assert.Equal(t, *body.Message, strconv.FormatInt(code, 10)+" "+resource+" not found", "error message in HTTP body data")
+}
+
+// AssertChartResourceBodyData asserts expected HTTP chart resource body data
+func AssertChartResourceBodyData(t *testing.T, chart models.Resource, body models.ResourceData) {
+	attributes, err := ChartResourceAttributesFromHTTPResponse(body)
+	assert.NoErr(t, err)
+	links, err := ChartResourceLinksFromHTTPResponse(body)
+	assert.NoErr(t, err)
+	assert.Equal(t, *chart.ID, *body.Data.ID, "chart ID data in HTTP body data")
+	assert.Equal(t, *chart.Type, *body.Data.Type, "chart type data in HTTP body data")
+	assert.Equal(t, *chart.Attributes.(*models.ChartResourceAttributes).Created, *attributes.Created, "chart created data in HTTP body data")
+	assert.Equal(t, *chart.Attributes.(*models.ChartResourceAttributes).Description, *attributes.Description, "chart descripion data in HTTP body data")
+	assert.Equal(t, *chart.Attributes.(*models.ChartResourceAttributes).Home, *attributes.Home, "chart home data in HTTP body data")
+	assert.Equal(t, *chart.Attributes.(*models.ChartResourceAttributes).Name, *attributes.Name, "chart name data in HTTP body data")
+	assert.Equal(t, *chart.Attributes.(*models.ChartResourceAttributes).Repo, *attributes.Repo, "chart repo data in HTTP body data")
+	assert.Equal(t, *chart.Links.(*models.ChartResourceLinks).Latest, *links.Latest, "chart link to latest data in HTTP body data")
+}
+
+// ResourceArrayDataFromJSON is a convenience that converts JSON to a models.ResourceArrayData
+func ResourceArrayDataFromJSON(r io.Reader, resource *models.ResourceArrayData) error {
+	return json.NewDecoder(r).Decode(resource)
+}
+
+// ResourceDataFromJSON is a convenience that converts JSON to a models.ResourceData
+func ResourceDataFromJSON(r io.Reader, resource *models.ResourceData) error {
+	return json.NewDecoder(r).Decode(resource)
+}
+
+// ErrorModelFromJSON is a convenience that converts JSON to a models.Error
+func ErrorModelFromJSON(r io.Reader, errorModel *models.Error) error {
+	return json.NewDecoder(r).Decode(errorModel)
+}
+
+// ChartResourceAttributesFromHTTPResponse is a convenience that grabs the Attributes interface from
+// a chart resource in generic models.ResourceData form and converts to a models.ChartResourceAttributes
+func ChartResourceAttributesFromHTTPResponse(body models.ResourceData) (models.ChartResourceAttributes, error) {
+	var attributes models.ChartResourceAttributes
+	b, err := json.Marshal(body.Data.Attributes.(map[string]interface{}))
+	if err != nil {
+		return attributes, err
+	}
+	err = json.Unmarshal(b, &attributes)
+	return attributes, err
+}
+
+// ChartResourceLinksFromHTTPResponse is a convenience that grabs the Links interface from
+// a chart resource in generic models.ResourceData form and converts to a models.ChartResourceLinks
+func ChartResourceLinksFromHTTPResponse(body models.ResourceData) (models.ChartResourceLinks, error) {
+	var links models.ChartResourceLinks
+	b, err := json.Marshal(body.Data.Links.(map[string]interface{}))
+	if err != nil {
+		return links, err
+	}
+	err = json.Unmarshal(b, &links)
+	return links, err
+}


### PR DESCRIPTION
including a new pkg/testutil package for common test conveniences

```
ok  	github.com/helm/monocular/src/api/data	0.116s	coverage: 91.7% of statements
ok  	github.com/helm/monocular/src/api/data/helpers	0.064s	coverage: 100.0% of statements
ok  	github.com/helm/monocular/src/api/handlers	0.138s	coverage: 90.9% of statements
ok  	github.com/helm/monocular/src/api/mocks	0.119s	coverage: 86.6% of statements
?   	github.com/helm/monocular/src/api/pkg/swagger/models	[no test files]
ok  	github.com/helm/monocular/src/api/pkg/swagger/restapi	0.211s	coverage: 12.7% of statements
?   	github.com/helm/monocular/src/api/pkg/swagger/restapi/operations	[no test files]
?   	github.com/helm/monocular/src/api/pkg/testutil	[no test files]
?   	github.com/helm/monocular/src/api	[no test files]
```