### PR TITLE
Upgrading the material2 package version

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -17,7 +17,7 @@
     "@angular/core": "2.0.0",
     "@angular/forms": "2.0.0",
     "@angular/http": "2.0.0",
-    "@angular/material": "^2.0.0-alpha.9-3",
+    "@angular/material": "2.0.0-alpha.11-2",
     "@angular/platform-browser": "2.0.0",
     "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "3.0.0",


### PR DESCRIPTION
Upgrading the version of material package fixes the bundle problem. However, this package still uses a beta package (5.0.0-beta.12)