### PR TITLE
Include Meta tags based on the current view

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -24,6 +24,7 @@
     "core-js": "^2.4.1",
     "hammerjs": "^2.0.8",
     "marked": "^0.3.6",
+    "ng2-meta": "^2.0.3",
     "rxjs": "5.0.3",
     "ts-helpers": "^1.1.1",
     "zone.js": "^0.7.4"

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -24,7 +24,7 @@
     "core-js": "^2.4.1",
     "hammerjs": "^2.0.8",
     "marked": "^0.3.6",
-    "ng2-meta": "^2.0.3",
+    "ng2-meta": "git://github.com/michaelmarriott/ng2-meta.git#8c09341b8d6d5b5ca417e9f3ddb1884f893814fc",
     "rxjs": "5.0.3",
     "ts-helpers": "^1.1.1",
     "zone.js": "^0.7.4"

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -24,7 +24,7 @@
     "core-js": "^2.4.1",
     "hammerjs": "^2.0.8",
     "marked": "^0.3.6",
-    "ng2-meta": "git://github.com/michaelmarriott/ng2-meta.git#8c09341b8d6d5b5ca417e9f3ddb1884f893814fc",
+    "ng2-meta": "git://github.com/Angelmmiguel/ng2-meta.git#8c09341b8d6d5b5ca417e9f3ddb1884f893814fc",
     "rxjs": "5.0.3",
     "ts-helpers": "^1.1.1",
     "zone.js": "^0.7.4"

--- a/src/ui/src/app/app.component.ts
+++ b/src/ui/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { MetaService } from 'ng2-meta';
 
 @Component({
   selector: 'app-root',
@@ -6,4 +7,5 @@ import { Component } from '@angular/core';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
+  constructor(private metaService: MetaService) {}
 }

--- a/src/ui/src/app/app.module.ts
+++ b/src/ui/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
+import { MetaModule, MetaConfig } from 'ng2-meta';
 import { routing, appRoutingProviders } from './app.routing';
 
 /* Material library */
@@ -38,6 +39,17 @@ import { ChartsFiltersComponent } from './charts-filters/charts-filters.componen
 
 require('hammerjs');
 
+const metaConfig: MetaConfig = {
+  //Append a title suffix such as a site name to all titles
+  //Defaults to false
+  useTitleSuffix: true,
+  defaults: {
+    title: 'Monocular',
+    titleSuffix: ' | Monocular',
+    description: 'Find the Helm chart you need or share your own Kubernetes apps'
+  }
+};
+
 @NgModule({
   declarations: [
     AppComponent,
@@ -68,7 +80,8 @@ require('hammerjs');
     BrowserModule,
     FormsModule,
     HttpModule,
-		routing
+		routing,
+    MetaModule.forRoot(metaConfig)
   ],
   providers: [
     appRoutingProviders,

--- a/src/ui/src/app/app.routing.ts
+++ b/src/ui/src/app/app.routing.ts
@@ -8,12 +8,45 @@ import { ChartSearchComponent } from './chart-search/chart-search.component';
 import { ChartsComponent } from './charts/charts.component';
 
 const appRoutes: Routes = [
-  { path: '', component: ChartIndexComponent },
-  { path: 'charts', component: ChartsComponent },
-  { path: 'charts/search', component: ChartSearchComponent },
-  { path: 'charts/:repo/:chartName', component: ChartDetailsComponent },
-  { path: 'charts/:repo/:chartName/:version', component: ChartDetailsComponent },
-  { path: '**', component: PageNotFoundComponent }
+  {
+    path: '',
+    component: ChartIndexComponent,
+    data: {
+      meta: {
+        title: 'Monocular'
+      }
+    }
+  },
+  {
+    path: 'charts',
+    component: ChartsComponent,
+    data: {
+      meta: {
+        title: 'All charts'
+      }
+    }
+  },
+  {
+    path: 'charts/search',
+    component: ChartSearchComponent
+  },
+  {
+    path: 'charts/:repo/:chartName',
+    component: ChartDetailsComponent
+  },
+  {
+    path: 'charts/:repo/:chartName/:version',
+    component: ChartDetailsComponent
+  },
+  {
+    path: '**',
+    component: PageNotFoundComponent,
+    data: {
+      meta: {
+        title: 'Not Found'
+      }
+    }
+  }
 ];
 
 export const appRoutingProviders: any[] = [

--- a/src/ui/src/app/chart-details/chart-details.component.ts
+++ b/src/ui/src/app/chart-details/chart-details.component.ts
@@ -11,8 +11,9 @@ import { MetaService } from 'ng2-meta';
 })
 export class ChartDetailsComponent implements OnInit {
   /* This resource will be different, probably ChartVersion */
-  chart: Chart
-  currentVersion: String
+  chart: Chart;
+  currentVersion: string;
+  titleVersion: string;
 
   constructor(
     private route: ActivatedRoute,
@@ -26,22 +27,35 @@ export class ChartDetailsComponent implements OnInit {
       let chartName = params['chartName']
       this.chartsService.getChart(repo, chartName)
         .subscribe(chart => {
-          this.chart = chart
-          this.currentVersion = params['version'] || this.chart.relationships.latestChartVersion.data.version
-          this.updateMetaTags(chart);
+          this.chart = chart;
+          this.currentVersion = params['version'] || this.chart.relationships.latestChartVersion.data.version;
+          this.titleVersion = params['version'] || '';
+          this.updateMetaTags();
         });
     });
   }
 
   /**
-   * Update the metatags with the name and the description of the application.
+   * Content for the title version tag
    *
-   * @param {Chart} chart The chart to get the name and the description.
+   * @return {string} Title to display in the site
    */
-  updateMetaTags(chart: Chart): void {
-    this.metaService.setTitle(chart.attributes.name);
-    this.metaService.setTag('description', chart.attributes.description);
-    this.metaService.setTag('og:title', chart.attributes.name);
-    this.metaService.setTag('og:description', chart.attributes.description);
+  contentTitleVersion(): string {
+    if (this.titleVersion.length > 0) {
+      return `${this.chart.attributes.name} ${this.titleVersion}`;
+    } else {
+      return this.chart.attributes.name;
+    }
+  }
+
+  /**
+   * Update the metatags with the name and the description of the application.
+   */
+  updateMetaTags(): void {
+    let title: string = this.contentTitleVersion();
+    this.metaService.setTitle(title);
+    this.metaService.setTag('description', this.chart.attributes.description);
+    this.metaService.setTag('og:title', title);
+    this.metaService.setTag('og:description', this.chart.attributes.description);
   }
 }

--- a/src/ui/src/app/chart-details/chart-details.component.ts
+++ b/src/ui/src/app/chart-details/chart-details.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
 import { ChartsService } from '../shared/services/charts.service';
 import { Chart } from '../shared/models/chart';
+import { MetaService } from 'ng2-meta';
 
 @Component({
   selector: 'app-chart-details',
@@ -15,7 +16,8 @@ export class ChartDetailsComponent implements OnInit {
 
   constructor(
     private route: ActivatedRoute,
-    private chartsService: ChartsService
+    private chartsService: ChartsService,
+    private metaService: MetaService
   ) { }
 
   ngOnInit() {
@@ -26,7 +28,20 @@ export class ChartDetailsComponent implements OnInit {
         .subscribe(chart => {
           this.chart = chart
           this.currentVersion = params['version'] || this.chart.relationships.latestChartVersion.data.version
-        })
-      })
+          this.updateMetaTags(chart);
+        });
+    });
+  }
+
+  /**
+   * Update the metatags with the name and the description of the application.
+   *
+   * @param {Chart} chart The chart to get the name and the description.
+   */
+  updateMetaTags(chart: Chart): void {
+    this.metaService.setTitle(chart.attributes.name);
+    this.metaService.setTag('description', chart.attributes.description);
+    this.metaService.setTag('og:title', chart.attributes.name);
+    this.metaService.setTag('og:description', chart.attributes.description);
   }
 }

--- a/src/ui/src/app/chart-search/chart-search.component.ts
+++ b/src/ui/src/app/chart-search/chart-search.component.ts
@@ -32,9 +32,7 @@ export class ChartSearchComponent implements OnInit {
       });
 
     // Update meta tags
-    setTimeout(() => {
-      this.updateMetaTags();
-    }, 10);
+    this.updateMetaTags();
   }
 
   searchCharts(q: String): void {

--- a/src/ui/src/app/chart-search/chart-search.component.ts
+++ b/src/ui/src/app/chart-search/chart-search.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ChartsService } from '../shared/services/charts.service';
+import { MetaService } from 'ng2-meta';
 import { Chart } from '../shared/models/chart';
 
 import { ActivatedRoute } from '@angular/router';
@@ -12,22 +13,28 @@ import 'rxjs/add/operator/map';
   styleUrls: ['./chart-search.component.scss']
 })
 export class ChartSearchComponent implements OnInit {
-  query: String;
+  query: string;
 	charts: Chart[] = []
 
   constructor(
     private route: ActivatedRoute,
-    private chartsService: ChartsService
+    private chartsService: ChartsService,
+    private metaService: MetaService
   ) { }
 
   ngOnInit() {
     this.route
       .queryParams
       .forEach(params => {
-        let q: String = params['q']
-        this.query = q
-        this.searchCharts(q)
-      })
+        let q: string = params['q']
+        this.query = q;
+        this.searchCharts(q);
+      });
+
+    // Update meta tags
+    setTimeout(() => {
+      this.updateMetaTags();
+    }, 10);
   }
 
   searchCharts(q: String): void {
@@ -36,9 +43,18 @@ export class ChartSearchComponent implements OnInit {
 
   resultMessage(): String {
     if (this.charts.length > 0) {
-      return this.charts.length + " results found for \"" + this.query + "\"";
+      return `${this.charts.length} results found for "${this.query}"`;
     } else {
-      return "\"" + this.query + "\" did not return any results";
+      return `"${this.query}" did not return any results`;
     }
+  }
+
+  /**
+   * Update the metatags with the string we are looking for.
+   */
+  updateMetaTags(): void {
+    let title: string = `Results for "${this.query}"`;
+    this.metaService.setTitle(title);
+    this.metaService.setTag('og:title', title);
   }
 }

--- a/src/ui/src/app/shared/models/chart.ts
+++ b/src/ui/src/app/shared/models/chart.ts
@@ -1,19 +1,20 @@
 import { ChartVersionAttributes } from "./chart-version"
 export class Chart {
-  id: String;
-  type: String;
-  links: String[];
+  id: string;
+  type: string;
+  links: string[];
   attributes: ChartAttributes;
   relationships: ChartRelationships;
 }
 
+
 export class ChartAttributes {
-  description: String;
-  name: String;
-  icon: String;
-  repo: String;
-  home: String;
-  sources: String[];
+  description: string;
+  name: string;
+  icon: string;
+  repo: string;
+  home: string;
+  sources: string[];
 }
 
 class ChartRelationships {
@@ -23,6 +24,6 @@ class ChartRelationships {
 class ChartVersionRelationship {
   data: ChartVersionAttributes
   links: {
-    self: String
+    self: string
   }
 }

--- a/src/ui/src/index.html
+++ b/src/ui/src/index.html
@@ -2,7 +2,10 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Helm UI</title>
+  <title>Monocular</title>
+  <meta name="description" content="Find the Helm chart you need or share your own Kubernetes apps">
+  <meta name="og:title" content="Monocular">
+  <meta name="og:description" content="Find the Helm chart you need or share your own Kubernetes apps">
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/png" href="favicon.png">


### PR DESCRIPTION
I added dynamic meta tags for SEO to the project. Now, we edit the title and description based on the current page:

![Home](https://cloud.githubusercontent.com/assets/4056725/22645267/80609ea4-ec66-11e6-9a05-b046c7f9197f.png)
![All charts](https://cloud.githubusercontent.com/assets/4056725/22645259/7bb3ffcc-ec66-11e6-918c-0185e5060fea.png)
![Search](https://cloud.githubusercontent.com/assets/4056725/22645260/7bb5ba9c-ec66-11e6-9f49-9ebc20d13f2d.png)
![Latest chart details](https://cloud.githubusercontent.com/assets/4056725/22645263/7bb8cb06-ec66-11e6-9568-86c089a421dd.png)
![Specific chart details](https://cloud.githubusercontent.com/assets/4056725/22645261/7bb7ecb8-ec66-11e6-838f-bf367e3e20bc.png)

To accomplish this task, I included a new library called [ng2-meta](https://github.com/vinaygopinath/ng2-meta). It works pretty well, but I found an issue when I set the tags in `ngOnInit` method. I investigated the error and found a [pull request](https://github.com/vinaygopinath/ng2-meta/pull/19) that solves the error. 

This PR is opened since November 2016, so **it seems the library is no longer maintained**. Meanwhile, I'm gonna use the project with the solution as a dependency. To prevent errors if the user removes that fork, **I forked it**. But this is a temporal solution, we need to find a better way to work with metatags.

Also, we need to think the correct descriptions for the main pages like All charts or Home.