### PR TITLE
Fix the flexbox property and padding

### DIFF
--- a/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.scss
+++ b/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.scss
@@ -15,4 +15,8 @@
     margin-right: .5em;
     font-weight: bold;
   }
+
+  code p:last-child {
+    margin-bottom: 0;
+  }
 }

--- a/src/ui/src/app/chart-details/chart-details.component.scss
+++ b/src/ui/src/app/chart-details/chart-details.component.scss
@@ -3,19 +3,15 @@
 
 .chart-details {
   width: 100%;
-  margin: 1em 0;
+  margin: 2em 0;
   padding: 0 2em;
-
-  &__info {
-    padding-top: 1em;
-  }
 
   @include mappy-bp(medium) {
     display: flex;
 
     &__info,
     &__docs {
-      padding: 1em;
+      padding: 0 1em;
     }
 
     &__info {
@@ -23,6 +19,7 @@
     }
 
     &__docs {
+      min-width: 0;
       flex: 3;
     }
   }


### PR DESCRIPTION
I only needed to add `min-width: 0` to prevent flex to push content outside the container. I found that solution in [CSS Tricks](https://css-tricks.com/flexbox-truncated-text/#article-header-id-3).

![Details](https://cloud.githubusercontent.com/assets/4056725/22646359/3f395dac-ec6c-11e6-9cf1-d46d7145f887.png)
