### PR TITLE
/charts endpoint

### DIFF
--- a/src/ui/src/app/app.routing.ts
+++ b/src/ui/src/app/app.routing.ts
@@ -27,6 +27,15 @@ const appRoutes: Routes = [
     }
   },
   {
+    path: 'charts/:repo',
+    component: ChartsComponent,
+    data: {
+      meta: {
+        title: 'All charts by repository'
+      }
+    }
+  },
+  {
     path: 'charts/search',
     component: ChartSearchComponent
   },

--- a/src/ui/src/app/chart-item/chart-item.component.html
+++ b/src/ui/src/app/chart-item/chart-item.component.html
@@ -7,7 +7,9 @@
       <p>
         <span class="chart-item-info__version" *ngIf="showVersion">
           v{{ chart.relationships.latestChartVersion.data.version }}</span>
-        <span class="chart-item-info__repo repo-{{chart.attributes.repo}}">{{ chart.attributes.repo }}</span>
+        <span class="chart-item-info__repo repo-{{chart.attributes.repo}}">
+          <a (click)="goToRepo(chart.attributes.repo)">{{ chart.attributes.repo }}</a>
+        </span>
       </p>
     </div>
   </div>

--- a/src/ui/src/app/chart-item/chart-item.component.scss
+++ b/src/ui/src/app/chart-item/chart-item.component.scss
@@ -54,6 +54,10 @@ $chart-item-content-height: 70px;
         border-color: md-color($monocular-app-warn, 600);
         background-color: md-color($monocular-app-warn);
       }
+
+      a {
+        color: inherit;
+      }
     }
 
     &__version {

--- a/src/ui/src/app/chart-item/chart-item.component.ts
+++ b/src/ui/src/app/chart-item/chart-item.component.ts
@@ -29,6 +29,11 @@ export class ChartItemComponent implements OnInit {
     this.router.navigate(link);
   }
 
+  goToRepo(repo: string): void {
+    let link = ['/charts', repo];
+    this.router.navigate(link);
+  }
+
   /**
    * Display the icon of the application if it's provided. In the other case,
    * It will return an string for a placeholder.

--- a/src/ui/src/app/charts-filters/charts-filters.component.ts
+++ b/src/ui/src/app/charts-filters/charts-filters.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'app-charts-filters',
@@ -6,18 +6,21 @@ import { Component, OnInit, Output, EventEmitter } from '@angular/core';
   styleUrls: ['./charts-filters.component.scss']
 })
 export class ChartsFiltersComponent implements OnInit {
+  @Input() currentRepo: string
+  @Output() onChange = new EventEmitter();
+
   // Order elements
   orderElements: {
     name: string,
     value: string
   }[] = [
     {
-      name: 'Title',
-      value: 'title'
+      name: 'Name',
+      value: 'name'
     },
     {
-      name: 'Repository',
-      value: 'repository'
+      name: 'Creation date',
+      value: 'created'
     }
   ];
   // Repository Types
@@ -41,13 +44,12 @@ export class ChartsFiltersComponent implements OnInit {
 
   // Order of the elements
   orderBy: string = this.orderElements[0].value;
-  repositoryType: string = this.repositoryElements[0].value;
+  repositoryType: string
 
-  @Output() onChange = new EventEmitter();
-
-  constructor() { }
+  constructor() {}
 
   ngOnInit() {
+    this.repositoryType = this.currentRepo || this.repositoryElements[0].value;
   }
 
   // Emit the changes of the filters

--- a/src/ui/src/app/charts/charts.component.html
+++ b/src/ui/src/app/charts/charts.component.html
@@ -1,7 +1,7 @@
 <app-header-bar></app-header-bar>
 
 <div class="charts__filters">
-  <app-charts-filters (onChange)="onChangeFilter($event)"></app-charts-filters>
+  <app-charts-filters (onChange)="onChangeFilter($event)" [currentRepo]="currentRepo"></app-charts-filters>
 </div>
 
 <app-panel [title]="'Helm Charts'" class="app-panel--container">

--- a/src/ui/src/app/charts/charts.component.ts
+++ b/src/ui/src/app/charts/charts.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ChartsService } from '../shared/services/charts.service';
 import { Chart } from '../shared/models/chart';
+import { ActivatedRoute, Params, Router } from '@angular/router';
 
 @Component({
   selector: 'app-charts',
@@ -10,56 +11,74 @@ import { Chart } from '../shared/models/chart';
 export class ChartsComponent implements OnInit {
   charts: Chart[] = [];
   orderedCharts: Chart[] = [];
-  constructor(private chartsService: ChartsService) { }
+  constructor(
+    private chartsService: ChartsService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) { }
 
   // Default filters
   filters = {
-    orderBy: 'title',
-    repositoryType: 'all'
+    orderBy: 'name'
   }
 
   ngOnInit() {
 		this.loadCharts();
   }
+  currentRepo: string
 
   loadCharts(): void {
-		this.chartsService.getCharts().subscribe(charts => {
-      this.charts = charts;
-      this.orderedCharts = this.orderCharts(this.filterCharts(charts));
-    });
+    this.route.params.forEach((params: Params) => {
+      this.currentRepo = params["repo"]
+  		this.chartsService.getCharts(this.currentRepo).subscribe(charts => {
+        this.charts = charts;
+        this.orderedCharts = this.orderCharts(this.charts);
+      });
+    })
   }
 
   // Update a filter
   onChangeFilter(filter): void {
     if (this.filters[filter.type] !== filter.value) {
+      // Repository change
+      if (filter.type == "repositoryType") {
+        return this.goToRepo(filter.value)
+      }
+
+      // in place filtering
       this.filters[filter.type] = filter.value;
-      this.orderedCharts = this.orderCharts(this.filterCharts(this.charts));
+      this.orderedCharts = this.orderCharts(this.charts);
     }
   }
 
-  // Filter and sort the charts
-  filterCharts(charts): Chart[] {
-    let filteredCharts = charts;
-    // Check if we need to apply a filter
-    if (this.filters.repositoryType !== 'all') {
-      filteredCharts = charts.filter(c =>
-        c.attributes.repo === this.filters.repositoryType);
-    }
-
-    return filteredCharts;
+  goToRepo(repo: string) {
+    if(repo == "all") repo = ""
+    let link = ['/charts', repo]
+    this.router.navigate(link);
   }
 
   // Sort charts
   orderCharts(charts): Chart[] {
     switch(this.filters.orderBy) {
-      case 'repository': {
-        return charts.sort((a, b) =>
-          a.attributes.repo.localeCompare(b.attributes.repo));
+      case 'created': {
+        return charts.sort(this.sortByCreated).reverse()
       }
       default: {
         return charts.sort((a, b) =>
           a.attributes.name.localeCompare(b.attributes.name));
       }
     }
+  }
+
+  private
+  sortByCreated(a: Chart, b: Chart) {
+      let aVersion = a.relationships.latestChartVersion.data
+      let bVersion = b.relationships.latestChartVersion.data
+      if(aVersion.created < bVersion.created){
+          return -1
+      } else if (aVersion.created > bVersion.created){
+        return 1
+      }
+      return 0
   }
 }

--- a/src/ui/src/app/shared/services/charts.service.ts
+++ b/src/ui/src/app/shared/services/charts.service.ts
@@ -22,8 +22,18 @@ export class ChartsService {
    *
    * @return {Observable} An observable that will an array with all Charts
    */
-  getCharts(): Observable<Chart[]> {
-    return this.http.get(`${this.hostname}/v1/charts`)
+  getCharts(repo: string = "all"): Observable<Chart[]> {
+    let url: string
+    switch(repo) {
+      case 'all' : {
+        url = `${this.hostname}/v1/charts`
+        break
+      }
+      default: {
+        url = `${this.hostname}/v1/charts/${repo}`
+      }
+    }
+    return this.http.get(url)
                   .map(this.extractData)
                   .catch(this.handleError);
   }


### PR DESCRIPTION
Extends the /charts endpoint to include the repo segment
![selection_113](https://cloud.githubusercontent.com/assets/24523/22804254/150fd1ce-eecd-11e6-9a46-991176e373cc.png)

Added sorting by Created at
![selection_114](https://cloud.githubusercontent.com/assets/24523/22804262/25f8d3dc-eecd-11e6-804c-54cd2cad4815.png)

Added link from card to new /charts/:repo endpoints
![selection_112](https://cloud.githubusercontent.com/assets/24523/22804275/2fbffd14-eecd-11e6-9c20-64f4684353e3.png)

Closes https://github.com/helm/monocular/issues/96