### PR TITLE
Include Analytics

### DIFF
--- a/helm/monocular/templates/ui-config.yaml
+++ b/helm/monocular/templates/ui-config.yaml
@@ -1,54 +1,16 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-ui
+  name: {{ template "fullname" . }}-ui-config
   labels:
+    app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 data:
-  vhost.conf: |+
-    upstream target_service {
-      server {{ template "fullname" . }}-prerender;
-    }
-
-    server {
-      listen 80;
-
-      location / {
-        try_files $uri @prerender;
+  overrides.js: |-
+    window.monocular = {
+      overrides: {
+        googleAnalyticsId: '{{.Values.ui.googleAnalyticsId}}'
       }
-
-      location @prerender {
-        set $prerender 0;
-
-        if ($http_user_agent ~* "baiduspider|twitterbot|facebookexternalhit|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator") {
-          set $prerender 1;
-        }
-
-        if ($args ~ "_escaped_fragment_") {
-          set $prerender 1;
-        }
-
-        if ($http_user_agent ~ "Prerender") {
-          set $prerender 0;
-        }
-
-        if ($uri ~* "\.(js|css|xml|less|png|jpg|jpeg|gif|pdf|doc|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|svg|eot)") {
-          set $prerender 0;
-        }
-
-        if ($prerender = 1) {
-          rewrite .* /https://$host$request_uri? break;
-          proxy_pass http://target_service;
-        }
-        if ($prerender = 0) {
-          rewrite .* /index.html break;
-        }
-      }
-    }
-
-    # Redirect www to non-www
-    # Taken from https://easyengine.io/tutorials/nginx/www-non-www-redirection/
-    server {
-      server_name "~^www\.(.*)$" ;
-      return 301 $scheme://$1$request_uri ;
-    }
+    };

--- a/helm/monocular/templates/ui-deployment.yaml
+++ b/helm/monocular/templates/ui-deployment.yaml
@@ -32,9 +32,16 @@ spec:
         volumeMounts:
           - name: vhost
             mountPath: /bitnami/nginx/conf/vhosts
+        volumeMounts:
+          - name: config
+            mountPath: /app/assets/js
         resources:
 {{ toYaml .Values.ui.resources | indent 12 }}
       volumes:
       - name: vhost
         configMap:
-          name: {{ template "fullname" . }}-ui
+          name: {{ template "fullname" . }}-ui-vhost
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "fullname" . }}-ui-config

--- a/helm/monocular/templates/ui-deployment.yaml
+++ b/helm/monocular/templates/ui-deployment.yaml
@@ -41,7 +41,6 @@ spec:
       - name: vhost
         configMap:
           name: {{ template "fullname" . }}-ui-vhost
-      volumes:
       - name: config
         configMap:
           name: {{ template "fullname" . }}-ui-config

--- a/helm/monocular/templates/ui-vhost.yaml
+++ b/helm/monocular/templates/ui-vhost.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-ui-vhost
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  vhost.conf: |+
+    upstream target_service {
+      server {{ template "fullname" . }}-prerender;
+    }
+
+    server {
+      listen 80;
+
+      location / {
+        try_files $uri @prerender;
+      }
+
+      location @prerender {
+        set $prerender 0;
+
+        if ($http_user_agent ~* "baiduspider|twitterbot|facebookexternalhit|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator") {
+          set $prerender 1;
+        }
+
+        if ($args ~ "_escaped_fragment_") {
+          set $prerender 1;
+        }
+
+        if ($http_user_agent ~ "Prerender") {
+          set $prerender 0;
+        }
+
+        if ($uri ~* "\.(js|css|xml|less|png|jpg|jpeg|gif|pdf|doc|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|svg|eot)") {
+          set $prerender 0;
+        }
+
+        if ($prerender = 1) {
+          rewrite .* /https://$host$request_uri? break;
+          proxy_pass http://target_service;
+        }
+        if ($prerender = 0) {
+          rewrite .* /index.html break;
+        }
+      }
+    }
+
+    # Redirect www to non-www
+    # Taken from https://easyengine.io/tutorials/nginx/www-non-www-redirection/
+    server {
+      server_name "~^www\.(.*)$" ;
+      return 301 $scheme://$1$request_uri ;
+    }

--- a/helm/monocular/values.yaml
+++ b/helm/monocular/values.yaml
@@ -37,6 +37,7 @@ ui:
     requests:
       cpu: 100m
       memory: 128Mi
+  googleAnalyticsId: UA-XXXXXX-X
 
 prerender:
   replicaCount: 1

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -24,6 +24,7 @@
     "@angular/platform-browser": "2.4.3",
     "@angular/platform-browser-dynamic": "2.4.3",
     "@angular/router": "3.4.3",
+    "angulartics2": "^1.6.3",
     "core-js": "^2.4.1",
     "hammerjs": "^2.0.8",
     "intl": "^1.2.5",

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -7,7 +7,7 @@
     "start": "ng serve",
     "lint": "tslint \"src/**/*.ts\"",
     "test": "ng test",
-    "test-ci": "ng test --single-run --code-coverage",
+    "test-ci": "ng test --single-run",
     "pree2e": "webdriver-manager update",
     "e2e": "protractor",
     "compile": "ng build --prod --progress=false",

--- a/src/ui/src/app/app.component.spec.ts
+++ b/src/ui/src/app/app.component.spec.ts
@@ -3,11 +3,12 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
-import { Angulartics2GoogleAnalytics } from 'angulartics2';
 
 import { AppComponent } from './app.component';
 import { FooterComponent } from './footer/footer.component';
 import { FooterListComponent } from './footer-list/footer-list.component';
+
+import { Angulartics2GoogleAnalytics } from 'angulartics2';
 
 describe('AppComponent', () => {
   let component: AppComponent;
@@ -18,6 +19,9 @@ describe('AppComponent', () => {
       declarations: [ AppComponent, FooterComponent, FooterListComponent ],
       imports: [
         RouterTestingModule
+      ],
+      providers: [
+        { provide: Angulartics2GoogleAnalytics }
       ]
     })
     .compileComponents();

--- a/src/ui/src/app/app.component.spec.ts
+++ b/src/ui/src/app/app.component.spec.ts
@@ -3,6 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
+import { Angulartics2GoogleAnalytics } from 'angulartics2';
 
 import { AppComponent } from './app.component';
 import { FooterComponent } from './footer/footer.component';

--- a/src/ui/src/app/app.component.ts
+++ b/src/ui/src/app/app.component.ts
@@ -1,3 +1,4 @@
+import { Angulartics2GoogleAnalytics } from 'angulartics2';
 import { Component } from '@angular/core';
 // import { MetaService } from 'ng2-meta';
 
@@ -8,5 +9,5 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   // constructor(private metaService: MetaService) {}
-  constructor() {}
+  constructor(angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics) {}
 }

--- a/src/ui/src/app/app.module.ts
+++ b/src/ui/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
+import { Angulartics2Module, Angulartics2GoogleAnalytics } from 'angulartics2';
 //import { MetaModule, MetaConfig } from 'ng2-meta';
 import { routing, appRoutingProviders } from './app.routing';
 
@@ -81,6 +82,7 @@ require('hammerjs');
     FormsModule,
     HttpModule,
 		routing,
+    Angulartics2Module.forRoot([Angulartics2GoogleAnalytics])
     //MetaModule.forRoot(metaConfig)
   ],
   providers: [

--- a/src/ui/src/assets/js/overrides.js
+++ b/src/ui/src/assets/js/overrides.js
@@ -1,0 +1,5 @@
+window.monocular = {
+  overrides: {
+    googleAnalyticsId: 'UA-XXXXXXXX-X'
+  }
+};

--- a/src/ui/src/index.html
+++ b/src/ui/src/index.html
@@ -21,5 +21,15 @@
       </div>
     </app-root>
   </div>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    // Set the last param to 'none' for development!
+    // Remember to replace the correct identifier for your project
+    ga('create', 'UA-XXXXXXXX-X', 'auto');
+  </script>
 </body>
 </html>

--- a/src/ui/src/index.html
+++ b/src/ui/src/index.html
@@ -12,6 +12,7 @@
   <link rel="icon" type="image/png" href="favicon.png">
   <link rel="stylesheet" href="assets/css/github-markdown.css">
   <link href="https://fonts.googleapis.com/css?family=Ubuntu:700" rel="stylesheet">
+  <script src="assets/js/overrides.js"></script>
 </head>
 <body>
   <div class='container'>
@@ -29,7 +30,7 @@
 
     // Set the last param to 'none' for development!
     // Remember to replace the correct identifier for your project
-    ga('create', 'UA-XXXXXXXX-X', 'auto');
+    ga('create', window.monocular.overrides.googleAnalyticsId, 'auto');
   </script>
 </body>
 </html>


### PR DESCRIPTION
I investigated how to include GA in Angular2 applications. First of all, I tried to implement a custom solution based on a `config.json` file that allow us to enable and disable the analytics. However, we couldn't use this because we cannot include `script` tags in angular templates. I must put the GA code in `index.html` file.

Finally, I used [angulartics/angulartics2](https://github.com/angulartics/angulartics2) project to send the `pageviews` events when the user changes the location. Also, this project has a good integration with events and components.

To prevent users to upload the GA keys, I put a placeholder for the identifier in `index.html`.

This closes #69 