### PR TITLE
Update Apache license in package.json

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Monocular",
   "version": "0.0.1",
-  "license": "Apache",
+  "license": "Apache-2.0",
   "angular-cli": {},
   "scripts": {
     "start": "ng serve",


### PR DESCRIPTION
As I wrote in #110, we must use the identifiers provided by [SPDX](https://spdx.org/licenses/). This closes #110.