### PR TITLE
chart: support multiple hosts in ingress

### DIFF
--- a/helm/monocular/templates/ingress.yaml
+++ b/helm/monocular/templates/ingress.yaml
@@ -14,18 +14,22 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   rules:
+  {{- range .Values.ingress.hosts }}
   - http:
       paths:
       - backend:
-          serviceName: {{ template "fullname" . }}-ui
-          servicePort: {{ .Values.ui.service.externalPort }}
+          serviceName: {{ template "fullname" $ }}-ui
+          servicePort: {{ $.Values.ui.service.externalPort }}
         path: /
       - backend:
-          serviceName: {{ template "fullname" . }}-api
-          servicePort: {{ .Values.api.service.externalPort }}
+          serviceName: {{ template "fullname" $ }}-api
+          servicePort: {{ $.Values.api.service.externalPort }}
         path: /api/
-    host: {{ .Values.ingress.hostname | quote }}
+    host: {{ . | quote }}
+  {{- end }}
 {{- if .Values.ingress.tls }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 -}}
+  - secretName: {{ .Values.ingress.tls.secretName }}
+    hosts:
+{{ toYaml .Values.ingress.hosts | indent 4 }}
 {{- end -}}

--- a/helm/monocular/templates/ui-config.yaml
+++ b/helm/monocular/templates/ui-config.yaml
@@ -45,3 +45,10 @@ data:
         }
       }
     }
+
+    # Redirect www to non-www
+    # Taken from https://easyengine.io/tutorials/nginx/www-non-www-redirection/
+    server {
+      server_name "~^www\.(.*)$" ;
+      return 301 $scheme://$1$request_uri ;
+    }

--- a/helm/monocular/values.yaml
+++ b/helm/monocular/values.yaml
@@ -56,11 +56,14 @@ prerender:
       memory: 128Mi
 
 ingress:
-  hostname: monocular.local
+  hosts:
+  # Wildcard
+  -
+  # - monocular.local
 
   ## Ingress annotations
   ##
-  # annotations:
+  annotations:
   #   kubernetes.io/ingress.class: nginx
   #   kubernetes.io/tls-acme: 'true'
 
@@ -68,6 +71,4 @@ ingress:
   ## Secrets must be manually created in the namespace
   ##
   # tls:
-  # - secretName: monocular.local-tls
-  #   hosts:
-  #   - monocular.local
+  #   secretName: monocular.local-tls


### PR DESCRIPTION
This adds support for specifying multiple hosts in ingress, forwarding
to the frontend and backends.

Also updates the UI's nginx config to redirect from non-www URLs.