### PR TITLE
Improve the loader using the same style of the application

### DIFF
--- a/src/ui/src/index.html
+++ b/src/ui/src/index.html
@@ -17,7 +17,12 @@
   <div class='container'>
     <app-root>
       <div class="main-loader">
-        <p>Loading...</p>
+        <h1 id="app-name"></h1>
+        <div class="spinner">
+          <svg class="circular" viewBox="25 25 50 50">
+            <circle class="path" cx="50" cy="50" r="20" fill="none" stroke-width="5" stroke-miterlimit="10"/>
+          </svg>
+        </div>
       </div>
     </app-root>
   </div>
@@ -30,6 +35,14 @@
     // Set the last param to 'none' for development!
     // Remember to replace the correct identifier for your project
     ga('create', window.monocular.overrides.googleAnalyticsId, 'auto');
+  </script>
+  <script type="text/javascript">
+    /**
+     * TODO: We must use a template system to include custom variables to the project
+     * I'm not happy defining this code.
+     */
+    var title = document.getElementById('app-name');
+    if (title) { title.innerHTML = window.monocular.overrides.appName; }
   </script>
 </body>
 </html>

--- a/src/ui/src/index.scss
+++ b/src/ui/src/index.scss
@@ -52,11 +52,6 @@
   }
 }
 
-@keyframes fadein {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-
 // Animations
 @keyframes rotate {
   100% {

--- a/src/ui/src/index.scss
+++ b/src/ui/src/index.scss
@@ -1,0 +1,80 @@
+// Imports
+@import '~@angular/material/core/theming/theming';
+@import './theme.scss';
+
+/**
+* This css is executed before load the Angular application. It includes the
+* loader of the main page.
+*
+* This code comes from the md-spinner of material2 repository. At this point,
+* the app is not loaded so I can't use the component.
+*/
+
+// Main loader
+.main-loader {
+  h1 {
+    text-align: center;
+    font-family: 'Ubuntu', Arial, sans-serif;
+    font-size: 3em;
+    margin: 2em 0 .5em;
+  }
+
+  .spinner {
+    position: relative;
+    margin: 0 auto;
+    width: 60px;
+
+    &:before {
+      content: '';
+      display: block;
+      padding-top: 100%;
+    }
+
+    .circular {
+      animation: rotate 2s linear infinite;
+      height: 100%;
+      transform-origin: center center;
+      width: 100%;
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      margin: auto;
+    }
+
+    .path {
+      stroke-dasharray: 1, 200;
+      stroke-dashoffset: 0;
+      stroke: md-color($monocular-app-primary);
+      animation: dash 1.5s ease-in-out infinite;
+    }
+  }
+}
+
+@keyframes fadein {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+// Animations
+@keyframes rotate {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes dash {
+  0% {
+    stroke-dasharray: 1, 200;
+    stroke-dashoffset: 0;
+  }
+  50% {
+    stroke-dasharray: 89, 200;
+    stroke-dashoffset: -35px;
+  }
+  100% {
+    stroke-dasharray: 89, 200;
+    stroke-dashoffset: -124px;
+  }
+}

--- a/src/ui/src/styles.scss
+++ b/src/ui/src/styles.scss
@@ -1,5 +1,6 @@
 // Imports
 @import './theme.scss';
+@import './index.scss';
 
 body {
   // Use system font-families now
@@ -44,27 +45,5 @@ a {
     &.active {
       color: md-color($monocular-app-primary);
     }
-  }
-}
-
-// Animations
-
-@keyframes fadein {
-    from { opacity: 0; }
-    to   { opacity: 1; }
-}
-
-// Main loader
-.main-loader {
-  height: 100vh;
-  background-color: $layout_base;
-  animation: fadein .3s;
-
-  p {
-    text-align: center;
-    font-size: 3em;
-    margin: 0;
-    color: $layout_light;
-    padding-top: 2em;
   }
 }


### PR DESCRIPTION
I used a pure CSS loader as the `md-spinner` component. I removed the dark background and add the name of the application dynamically.

I'm not happy with the current approach of  editing the content of the `h1`. However, adding a template system to `angular-cli` is not trivial.

This closes #135.

## Screenshot
![Loader](https://cloud.githubusercontent.com/assets/4056725/23020042/66576dbc-f445-11e6-9730-b24dbdde1e67.png)
![Loader in other browsers](https://cloud.githubusercontent.com/assets/4056725/23020048/6e7e2364-f445-11e6-8d89-78a4755e8498.png)

