### PR TITLE
Fix Slack link in the footer

### DIFF
--- a/src/ui/src/app/footer/footer.component.html
+++ b/src/ui/src/app/footer/footer.component.html
@@ -1,7 +1,7 @@
 <footer class="footer">
   <app-footer-list [title]="'Collaborate'">
     <li><a class="reverse" target="_blank" href="https://github.com/helm/monocular">Github</a></li>
-    <li><a class="reverse" target="_blank" href="https://slack.k8s.io/#helm">Slack</a></li>
+    <li><a class="reverse" target="_blank" href="http://slack.k8s.io/#helm">Slack</a></li>
     <li><a class="reverse" target="_blank" href="https://twitter.com/helmpack">Twitter</a></li>
   </app-footer-list>
   <app-footer-list [title]="'How to use'">


### PR DESCRIPTION
Slack link doesn't use HTTPS.

This closes #143 