### PR TITLE
Use anchors instead of javascript listeners. Clickable logos

### DIFF
--- a/src/ui/src/app/chart-details/chart-details-versions/chart-details-versions.component.html
+++ b/src/ui/src/app/chart-details/chart-details-versions/chart-details-versions.component.html
@@ -2,7 +2,8 @@
   <h1>Versions</h1>
   <div class="version" *ngFor="let version of versions">
     <span class='number' [class.selected]="isSelected(version)">
-      <a (click)="goToVersion(version)">{{ version.attributes.version }}</a>
+      <a [href]="goToVersionUrl(version)" [routerLink]="goToVersionUrl(version)">
+        {{ version.attributes.version }}</a>
     </span> -
     <span class='creation-date'>{{ version.attributes.created | date: 'MMM d, y' }}</span>
   </div>

--- a/src/ui/src/app/chart-details/chart-details-versions/chart-details-versions.component.ts
+++ b/src/ui/src/app/chart-details/chart-details-versions/chart-details-versions.component.ts
@@ -14,7 +14,7 @@ export class ChartDetailsVersionsComponent implements OnInit {
 
   ngOnInit() { }
 
-	goToVersionUrl(version: ChartVersion): string {
+  goToVersionUrl(version: ChartVersion): string {
     let chart: ChartAttributes = version.relationships.chart.data
     return `/charts/${chart.repo.name}/${chart.name}/${version.attributes.version}`;
   }

--- a/src/ui/src/app/chart-details/chart-details-versions/chart-details-versions.component.ts
+++ b/src/ui/src/app/chart-details/chart-details-versions/chart-details-versions.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { ChartVersion } from '../../shared/models/chart-version';
 import { ChartAttributes } from '../../shared/models/chart';
-import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-chart-details-versions',
@@ -11,16 +10,13 @@ import { Router } from '@angular/router';
 export class ChartDetailsVersionsComponent implements OnInit {
   @Input() versions: ChartVersion[]
   @Input() currentVersion: string
-  constructor(
-    private router: Router,
-  ) { }
+  constructor() { }
 
   ngOnInit() { }
 
-	goToVersion(version: ChartVersion): void {
-    var chart: ChartAttributes = version.relationships.chart.data
-    let link = ['/charts', chart.repo.name, chart.name, version.attributes.version];
-    this.router.navigate(link);
+	goToVersionUrl(version: ChartVersion): string {
+    let chart: ChartAttributes = version.relationships.chart.data
+    return `/charts/${chart.repo.name}/${chart.name}/${version.attributes.version}`;
   }
 
   isSelected(version: ChartVersion): boolean {

--- a/src/ui/src/app/chart-item/chart-item.component.html
+++ b/src/ui/src/app/chart-item/chart-item.component.html
@@ -1,16 +1,21 @@
 <div class="chart-item {{ fixHeight ? 'chart-item--fixHeight' : '' }}">
   <div class="chart-item-content">
     <div class="chart-item-logo">
-      <img alt="{{ chart.attributes.name }}'s logo" src="{{ getIconUrl(chart) }}"/>
+      <a [href]="goToDetailUrl()" [routerLink]="goToDetailUrl()">
+        <img alt="{{ chart.attributes.name }}'s logo" src="{{ getIconUrl() }}"/>
+      </a>
     </div>
     <div class="chart-item-info">
-      <h2 class="chart-item-info__title" (click)="goToDetail(chart)">
-        {{ chart.attributes.name }}</h2>
+      <h2 class="chart-item-info__title">
+        <a [href]="goToDetailUrl()" [routerLink]="goToDetailUrl()">
+          {{ chart.attributes.name }}</a>
+      </h2>
       <p>
         <span class="chart-item-info__version" *ngIf="showVersion">
           v{{ chart.relationships.latestChartVersion.data.version }}</span>
         <span class="chart-item-info__repo repo-{{chart.attributes.repo.name}}">
-          <a (click)="goToRepo(chart.attributes.repo.name)">{{ chart.attributes.repo.name }}</a>
+          <a [href]="goToRepoUrl()" [routerLink]="goToRepoUrl()">
+            {{ chart.attributes.repo.name }}</a>
         </span>
       </p>
     </div>

--- a/src/ui/src/app/chart-item/chart-item.component.ts
+++ b/src/ui/src/app/chart-item/chart-item.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
 import { Chart } from '../shared/models/chart';
 import { ConfigService } from '../shared/services/config.service';
 
@@ -20,21 +19,18 @@ export class ChartItemComponent implements OnInit {
   public fixHeight: boolean = false;
 
   constructor(
-    private router: Router,
     private config: ConfigService
   ) {}
 
   ngOnInit() {
   }
 
-	goToDetail(chart: Chart): void {
-    let link = ['/charts', chart.attributes.repo.name, chart.attributes.name];
-    this.router.navigate(link);
+	goToDetailUrl(): string {
+    return `/charts/${this.chart.attributes.repo.name}/${this.chart.attributes.name}`;
   }
 
-  goToRepo(repo: string): void {
-    let link = ['/charts', repo];
-    this.router.navigate(link);
+  goToRepoUrl(): string {
+    return `/charts/${this.chart.attributes.repo.name}`;
   }
 
   /**
@@ -43,8 +39,8 @@ export class ChartItemComponent implements OnInit {
    *
    * @return {string} The URL of the icon or a placeholder
    */
-  getIconUrl(chart: Chart): string {
-    let icons = chart.relationships.latestChartVersion.data.icons;
+  getIconUrl(): string {
+    let icons = this.chart.relationships.latestChartVersion.data.icons;
     if (icons !== undefined && icons.length > 0) {
       return this.config.backendHostname + icons.find(icon => icon.name === '160x160-fit').path;
     } else {

--- a/src/ui/src/app/chart-item/chart-item.component.ts
+++ b/src/ui/src/app/chart-item/chart-item.component.ts
@@ -25,7 +25,7 @@ export class ChartItemComponent implements OnInit {
   ngOnInit() {
   }
 
-	goToDetailUrl(): string {
+  goToDetailUrl(): string {
     return `/charts/${this.chart.attributes.repo.name}/${this.chart.attributes.name}`;
   }
 

--- a/src/ui/src/app/charts/charts.component.ts
+++ b/src/ui/src/app/charts/charts.component.ts
@@ -55,9 +55,8 @@ export class ChartsComponent implements OnInit {
   }
 
   goToRepo(repo: string) {
-    if(repo == "all") repo = ""
-    let link = ['/charts', repo]
-    this.router.navigate(link);
+    repo = repo === 'all' ? '' : repo;
+    this.router.navigate(['/charts', repo]);
   }
 
   // Sort charts

--- a/src/ui/src/app/header-bar/chart-search-input/chart-search-input.component.ts
+++ b/src/ui/src/app/header-bar/chart-search-input/chart-search-input.component.ts
@@ -13,16 +13,15 @@ export class ChartSearchInputComponent implements OnInit {
 
   searchCharts(input: HTMLInputElement): void {
     // Empty query
-    if(input.value === ""){
-      this.router.navigate(["/"])
-      return
+    if(input.value === ''){
+      this.router.navigate(['/'])
+    } else {
+      let navigationExtras: NavigationExtras = {
+        queryParams: { 'q': input.value }
+      };
+      input.value = '';
+      this.router.navigate(['/charts/search'], navigationExtras)
     }
-
-    let navigationExtras: NavigationExtras = {
-      queryParams: { 'q': input.value }
-    };
-    input.value = ''
-    this.router.navigate(["/charts/search"], navigationExtras)
   }
 
 }

--- a/src/ui/src/app/header-bar/header-bar.component.ts
+++ b/src/ui/src/app/header-bar/header-bar.component.ts
@@ -32,7 +32,7 @@ export class HeaderBarComponent implements OnInit {
       let navigationExtras: NavigationExtras = {
         queryParams: { 'q': input.value }
       };
-      this.router.navigate(["/charts/search"], navigationExtras);
+      this.router.navigate(['/charts/search'], navigationExtras);
     }
   }
 }

--- a/src/ui/src/app/main-header/main-header.component.ts
+++ b/src/ui/src/app/main-header/main-header.component.ts
@@ -14,14 +14,13 @@ export class MainHeaderComponent implements OnInit {
 
   searchCharts(input: HTMLInputElement): void {
     // Empty query
-    if(input.value === ""){
-      this.router.navigate(["/"]);
-      return;
+    if(input.value === ''){
+      this.router.navigate(['/']);
+    } else {
+      let navigationExtras: NavigationExtras = {
+        queryParams: { 'q': input.value }
+      };
+      this.router.navigate(['/charts/search'], navigationExtras);
     }
-
-    let navigationExtras: NavigationExtras = {
-      queryParams: { 'q': input.value }
-    };
-    this.router.navigate(["/charts/search"], navigationExtras)
   }
 }


### PR DESCRIPTION
When we use a prerendered version of the page (SEO friendly), the navigation elements must include the `href` property, so we must use anchors.

This closes #119 and #132.