### PR TITLE
Fix UI in Firefox

### DIFF
--- a/src/ui/src/app/chart-details/chart-details-info/chart-details-info.component.scss
+++ b/src/ui/src/app/chart-details/chart-details-info/chart-details-info.component.scss
@@ -3,4 +3,10 @@
   &__maintainers {
     margin-bottom: 2em;
   }
+
+  &__sources {
+    a {
+      word-break: break-all;
+    }
+  }
 }

--- a/src/ui/src/app/chart-details/chart-details.component.scss
+++ b/src/ui/src/app/chart-details/chart-details.component.scss
@@ -15,7 +15,7 @@
     }
 
     &__info {
-      flex: 1;
+      width: 35%;
     }
 
     &__docs {

--- a/src/ui/src/app/chart-item/chart-item.component.html
+++ b/src/ui/src/app/chart-item/chart-item.component.html
@@ -1,4 +1,4 @@
-<div class="chart-item {{ fixHeight ? 'chart-item--fixHeight' : '' }}">
+<div class="chart-item">
   <div class="chart-item-content">
     <div class="chart-item-logo">
       <img alt="{{ chart.attributes.name }}'s logo" src="{{ getIconUrl(chart) }}"/>

--- a/src/ui/src/app/chart-item/chart-item.component.scss
+++ b/src/ui/src/app/chart-item/chart-item.component.scss
@@ -10,11 +10,6 @@ $chart-item-content-height: 80px;
   border: 1px solid #eaeaea;
   border-radius: $border-radius;
 
-  // Useful to display the elements as a grid
-  &.chart-item--fixHeight {
-    min-height: 10em;
-  }
-
   &-content {
     text-align: center;
   }

--- a/src/ui/src/app/chart-item/chart-item.component.ts
+++ b/src/ui/src/app/chart-item/chart-item.component.ts
@@ -7,7 +7,7 @@ import { ConfigService } from '../shared/services/config.service';
   selector: 'app-chart-item',
   templateUrl: './chart-item.component.html',
   styleUrls: ['./chart-item.component.scss'],
-  inputs: ['chart', 'showVersion', 'showDescription', 'fixHeight']
+  inputs: ['chart', 'showVersion', 'showDescription']
 })
 export class ChartItemComponent implements OnInit {
   // Chart to represent
@@ -16,8 +16,6 @@ export class ChartItemComponent implements OnInit {
   public showVersion: boolean = true;
   // Truncate the description
   public showDescription: boolean = true;
-  // Fix the height of the elements
-  public fixHeight: boolean = false;
 
   constructor(
     private router: Router,

--- a/src/ui/src/app/chart-list/chart-list.component.html
+++ b/src/ui/src/app/chart-list/chart-list.component.html
@@ -1,3 +1,3 @@
 <section class="chart-list">
-  <app-chart-item *ngFor="let chart of charts" [chart]=chart [fixHeight]=true [showDescription]=false></app-chart-item>
+  <app-chart-item *ngFor="let chart of charts" [chart]=chart [showDescription]=false></app-chart-item>
 </section>

--- a/src/ui/src/app/chart-list/chart-list.component.scss
+++ b/src/ui/src/app/chart-list/chart-list.component.scss
@@ -5,7 +5,7 @@
   display: flex;
   flex-flow: row wrap;
   justify-content: space-between;
-  margin-bottom: -2%;
+  margin-bottom: -2vw;
 
   &:after {
     content: "";
@@ -19,13 +19,13 @@
 
     // Responsive
     @include mappy-bp(small) {
-      margin: 0 0 2% 2%;
+      margin: 0 0 2vw 2%;
     }
   }
 
   @include mappy-bp(small medium) {
     app-chart-item {
-      width: 48%;
+      width: 49%;
 
       &:nth-child(2n+1) {
         margin-left: 0;

--- a/src/ui/src/app/charts-filters/charts-filters.component.scss
+++ b/src/ui/src/app/charts-filters/charts-filters.component.scss
@@ -15,17 +15,27 @@
       color: md-color($monocular-app-primary);
       margin-bottom: .5em;
       font-weight: bold;
+      display: block;
     }
 
     &__select {
       display: inline-block;
-      margin-left: 1em;
-      width: 235px;
       vertical-align: middle;
     }
 
     &:last-child {
       margin-right: 0;
+    }
+
+    @include mappy-bp(medium) {
+      &__title {
+        display: inline-block;
+      }
+
+      &__select {
+        width: 235px;
+        margin-left: 1em;
+      }
     }
   }
 }

--- a/src/ui/src/app/header-bar/header-bar.component.scss
+++ b/src/ui/src/app/header-bar/header-bar.component.scss
@@ -5,6 +5,7 @@
 
 // Variables
 $header-bar-padding: 1.5em 2em;
+$header-bar-padding-small: 1.5em;
 
 .header-bar {
   padding: $header-bar-padding;
@@ -27,8 +28,8 @@ $header-bar-padding: 1.5em 2em;
   }
 
   &__search {
-    float: right;
-
+    margin-top: .5em;
+    
     .md-input-wrapper {
       margin: .4em 0;
     }
@@ -47,6 +48,17 @@ $header-bar-padding: 1.5em 2em;
           padding: 1em;
         }
       }
+    }
+  }
+
+  @include mappy-bp(max-width small) {
+    padding: $header-bar-padding-small;
+  }
+
+  @include mappy-bp(small) {
+    &__search {
+      margin-top: 0;
+      float: right;
     }
   }
 }

--- a/src/ui/src/app/main-header/main-header.component.html
+++ b/src/ui/src/app/main-header/main-header.component.html
@@ -3,7 +3,7 @@
   <div class="main-header-content">
     <div class="main-header-content__slogan">
       <p>
-        Discover & launch great Kubernetes-ready apps
+        Discover & launch great Kubernetes-<wbr>ready apps
       </p>
     </div>
     <div class="main-header-search">

--- a/src/ui/src/app/main-header/main-header.component.scss
+++ b/src/ui/src/app/main-header/main-header.component.scss
@@ -13,8 +13,13 @@ $main-header-height: 400px;
   border-bottom: 3px solid black;
 
   &-content {
-    width: 80%;
-    margin: 1.5em auto 0;
+    width: 100%;
+    padding: 1.5em;
+
+    @include mappy-bp(small) {
+      width: 80%;
+      margin: 1.5em auto 0;
+    }
 
     @include mappy-bp(medium) {
       display: flex;


### PR DESCRIPTION
The calculations of percent vertical margins of flex elements is slightly different in Firefox. In our current case, we can not use percent margins for the elements. However, the list fill the width viewport, so I replaced `%` unities for `vw`.

Also, I checked the UI in other browsers:

* Firefox
* Chrome
* Safari
* Opera

Finally, I fixed the width of the sidebar in details view and improve the responsive design.

This closes #147 

## Firefox

![Firefox](https://cloud.githubusercontent.com/assets/4056725/23027213/e8d418e4-f463-11e6-9b43-1570db89ad3e.png)

## Fix sidebar width to 35%

![Sidebar](https://cloud.githubusercontent.com/assets/4056725/23027257/04b74af4-f464-11e6-985b-619455dea10c.png)

## Mobile

![Mobile](https://cloud.githubusercontent.com/assets/4056725/23027126/a969a9e4-f463-11e6-89a9-cfe4c94dc490.png)
![Charts view](https://cloud.githubusercontent.com/assets/4056725/23027154/c0c9c7cc-f463-11e6-8a15-951c8f51ca26.png)

