### PR TITLE
chart: fix ui-deployment volume mounts

### DIFF
--- a/helm/monocular/templates/ui-deployment.yaml
+++ b/helm/monocular/templates/ui-deployment.yaml
@@ -32,7 +32,6 @@ spec:
         volumeMounts:
           - name: vhost
             mountPath: /bitnami/nginx/conf/vhosts
-        volumeMounts:
           - name: config
             mountPath: /app/assets/js
         resources:


### PR DESCRIPTION
Fixes a bug in the chart that was only one configmap to mount