### PR TITLE
Add "Copy to clipboard" to installation commands

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -30,6 +30,7 @@
     "intl": "^1.2.5",
     "marked": "^0.3.6",
     "ng2-meta": "git://github.com/Angelmmiguel/ng2-meta.git#8c09341b8d6d5b5ca417e9f3ddb1884f893814fc",
+    "ngx-clipboard": "^3.0.5",
     "rxjs": "5.0.3",
     "ts-helpers": "^1.1.1",
     "zone.js": "^0.7.4"

--- a/src/ui/src/app/app.module.ts
+++ b/src/ui/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 import { Angulartics2Module, Angulartics2GoogleAnalytics } from 'angulartics2';
+import { ClipboardModule } from 'ngx-clipboard';
 //import { MetaModule, MetaConfig } from 'ng2-meta';
 import { routing, appRoutingProviders } from './app.routing';
 
@@ -83,7 +84,8 @@ require('hammerjs');
     FormsModule,
     HttpModule,
 		routing,
-    Angulartics2Module.forRoot([Angulartics2GoogleAnalytics])
+    Angulartics2Module.forRoot([Angulartics2GoogleAnalytics]),
+    ClipboardModule
     //MetaModule.forRoot(metaConfig)
   ],
   providers: [

--- a/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
+++ b/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
@@ -1,6 +1,6 @@
 <app-panel class="chart-details-usage" [border]=true>
   <div *ngIf=showRepoInstructions class="chart-details-usage__repository">
-    <h2 class="chart-details-usage__label">Add incubator repository</h2>
+    <h2 class="chart-details-usage__label">Add {{ chart.attributes.repo.name }} repository</h2>
     <md-input floatingPlaceholder=false [value]=repoAddInstructions></md-input>
     <button md-button ngxClipboard [cbContent]="repoAddInstructions" (cbOnSuccess)="showSnackBar()"
       angulartics2On="click" angularticsEvent="RepositoryCopy" angularticsCategory="{{ cmdChartId }}"

--- a/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
+++ b/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
@@ -2,15 +2,16 @@
   <div *ngIf=showRepoInstructions class="chart-details-usage__repository">
     <h2 class="chart-details-usage__label">Add incubator repository</h2>
     <md-input floatingPlaceholder=false [value]=repoAddInstructions></md-input>
-    <button md-button ngxClipboard [cbContent]="repoAddInstructions"
-      angulartics2On="click" angularticsEvent="RepositoryCopy">
+    <button md-button ngxClipboard [cbContent]="repoAddInstructions" (cbOnSuccess)="showSnackBar()"
+      angulartics2On="click" angularticsEvent="RepositoryCopy" angularticsCategory="{{ cmdChartId }}"
+      [angularticsProperties]="{ label: currentVersion }">
       <md-icon svgIcon="content-copy"></md-icon>
     </button>
   </div>
   <div>
     <h2 class="chart-details-usage__label">Install chart</h2>
     <md-input readonly=true floatingPlaceholder=false [value]=installInstructions></md-input>
-    <button md-button ngxClipboard [cbContent]="installInstructions"
+    <button md-button ngxClipboard [cbContent]="installInstructions" (cbOnSuccess)="showSnackBar()"
       angulartics2On="click" angularticsEvent="ChartInstallationCopy"
       angularticsCategory="{{ cmdChartId }}" [angularticsProperties]="{ label: currentVersion }">
       <md-icon svgIcon="content-copy"></md-icon>

--- a/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
+++ b/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
@@ -1,7 +1,19 @@
-<div class="chart-details-usage">
-  <label>Usage</label>
-  <code>
-    <p *ngIf="showRepoInstructions">{{ repoAddInstructions }}</p>
-    <p>helm install {{ cmdChartId }} --version {{ currentVersion }}</p>
-  </code>
-</div>
+<app-panel class="chart-details-usage" [border]=true>
+  <div *ngIf=showRepoInstructions class="chart-details-usage__repository">
+    <h2 class="chart-details-usage__label">Add incubator repository</h2>
+    <md-input floatingPlaceholder=false [value]=repoAddInstructions></md-input>
+    <button md-button ngxClipboard [cbContent]="repoAddInstructions"
+      angulartics2On="click" angularticsEvent="RepositoryCopy">
+      <md-icon svgIcon="content-copy"></md-icon>
+    </button>
+  </div>
+  <div>
+    <h2 class="chart-details-usage__label">Install chart</h2>
+    <md-input readonly=true floatingPlaceholder=false [value]=installInstructions></md-input>
+    <button md-button ngxClipboard [cbContent]="installInstructions"
+      angulartics2On="click" angularticsEvent="ChartInstallationCopy"
+      angularticsCategory="{{ cmdChartId }}" [angularticsProperties]="{ label: currentVersion }">
+      <md-icon svgIcon="content-copy"></md-icon>
+    </button>
+  </div>
+</app-panel>

--- a/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.scss
+++ b/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.scss
@@ -4,20 +4,37 @@
 @import '../../../theme.scss';
 
 .chart-details-usage {
-  background-color: $layout_base;
-  color: $layout_light;
+  display: block;
   margin: 2em 0;
-  padding: 2em;
-  border-radius: $border-radius;
+  box-shadow: 1px 1px 10px rgba(0, 0, 0, .07);
 
-  label {
-    color: md-color($monocular-app-primary);
-    display: inline-block;
-    margin-right: .5em;
-    font-weight: bold;
+  .panel--border {
+    border-right: 2px solid md-color($monocular-app-primary, 300) !important;
   }
 
-  code p:last-child {
-    margin-bottom: 0;
+  &__label {
+    margin: 0 0 .1em;
+    font-size: 1em;
+  }
+
+  &__repository {
+    margin-bottom: 1.5em;
+  }
+
+  md-input {
+    width: calc(100% - 5em);
+
+    .md-input-wrapper {
+      margin: 1em 0 .5em;
+    }
+  }
+
+  [md-button] {
+    margin-left: 1em;
+    min-width: 4em;
+  }
+
+  svg {
+    fill: md-color($monocular-app-primary);
   }
 }

--- a/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.ts
+++ b/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.ts
@@ -1,7 +1,8 @@
-import { Component, OnInit, Input, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, Input, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
 import { Chart } from '../../shared/models/chart';
 import { DomSanitizer } from '@angular/platform-browser';
 import { MdIconRegistry } from '@angular/material';
+import {MdSnackBar} from '@angular/material';
 
 @Component({
   selector: 'app-chart-details-usage',
@@ -16,7 +17,8 @@ export class ChartDetailsUsageComponent implements OnInit {
 
   constructor(
     mdIconRegistry: MdIconRegistry,
-    sanitizer: DomSanitizer
+    sanitizer: DomSanitizer,
+    public snackBar: MdSnackBar
   ) {
     mdIconRegistry
       .addSvgIcon('content-copy',
@@ -24,6 +26,13 @@ export class ChartDetailsUsageComponent implements OnInit {
   }
 
   ngOnInit() {}
+
+  // Show an snack bar to confirm the user that the code has been copied
+  showSnackBar(): void {
+    this.snackBar.open('Copied to the clipboard', '', {
+      duration: 1500,
+    });
+  }
 
   // Deletes /stable prefix not needed for stable repos
   get cmdChartId(): string {

--- a/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.ts
+++ b/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.ts
@@ -1,16 +1,27 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, ViewEncapsulation } from '@angular/core';
 import { Chart } from '../../shared/models/chart';
+import { DomSanitizer } from '@angular/platform-browser';
+import { MdIconRegistry } from '@angular/material';
 
 @Component({
   selector: 'app-chart-details-usage',
   templateUrl: './chart-details-usage.component.html',
-  styleUrls: ['./chart-details-usage.component.scss']
+  styleUrls: ['./chart-details-usage.component.scss'],
+  viewProviders: [MdIconRegistry],
+  encapsulation: ViewEncapsulation.None
 })
 export class ChartDetailsUsageComponent implements OnInit {
   @Input() chart: Chart
   @Input() currentVersion: string
 
-  constructor() { }
+  constructor(
+    mdIconRegistry: MdIconRegistry,
+    sanitizer: DomSanitizer
+  ) {
+    mdIconRegistry
+      .addSvgIcon('content-copy',
+        sanitizer.bypassSecurityTrustResourceUrl('/assets/icons/content-copy.svg'))
+  }
 
   ngOnInit() {}
 
@@ -24,6 +35,10 @@ export class ChartDetailsUsageComponent implements OnInit {
   }
 
   get repoAddInstructions(): string {
-    return `helm repo add incubator ${this.chart.attributes.repo.url}`
+    return `helm repo add incubator ${this.chart.attributes.repo.url}`;
+  }
+
+  get installInstructions(): string {
+    return `helm install ${this.cmdChartId} --version ${this.currentVersion}`;
   }
 }

--- a/src/ui/src/assets/icons/content-copy.svg
+++ b/src/ui/src/assets/icons/content-copy.svg
@@ -1,0 +1,4 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+</svg>


### PR DESCRIPTION
I added "Copy To Clipboard" feature for the commands we display in the Chart Details view. I followed the approach that @migmartri defined in #157. 

I changed the background of the panel and added a border and box shadow. I want to highlight this section of the view.

![Chart details](https://cloud.githubusercontent.com/assets/4056725/23068928/d57e00b2-f525-11e6-8059-231cecf63b1f.png)

Also, when the user clicks on the button, we display an Snack Bar to confirm the action. I tried to use the `tooltip` component, but it's fired automatically on `hover` event, so we can't show it programatically.

![Copied to clipboard confirmation](https://cloud.githubusercontent.com/assets/4056725/23068962/eb1672e2-f525-11e6-921a-18f01ae2a049.png)

Finally, I added two GA events to the buttons.

This closes #157 

