### PR TITLE
Fix the copy button in Firefox

### DIFF
--- a/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.scss
+++ b/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.scss
@@ -31,7 +31,8 @@
 
   [md-button] {
     margin-left: 1em;
-    min-width: 4em;
+    min-width: auto;
+    width: 4em;
   }
 
   svg {


### PR DESCRIPTION
I fix the size of the button to `4em`. I tested it in:

* Opera
* Safari
* Chrome
* Firefox

This closes #175 

![Firefox](https://cloud.githubusercontent.com/assets/4056725/23208926/422d0666-f8f7-11e6-97d7-dfffbf0b21d2.png)
