### PR TITLE
Cache charts in the service

### DIFF
--- a/src/ui/src/app/app.component.ts
+++ b/src/ui/src/app/app.component.ts
@@ -2,12 +2,13 @@ import { Angulartics2GoogleAnalytics } from 'angulartics2';
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { MenuService } from './shared/services/menu.service';
+import { ChartsService } from './shared/services/charts.service';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
-  providers: [MenuService]
+  providers: [MenuService, ChartsService]
 })
 export class AppComponent {
   // Show the global menu


### PR DESCRIPTION
The user shouldn't need to load the charts every time she/he navigates in the application. To solve this, I cache the charts in the service. To provide the same service for all components, I declared it in the `AppComponent`.

This closes #176 

**Note**: I removed the `console.log` statements before send the PR.

![Logging cache messages to display the feature](https://cloud.githubusercontent.com/assets/4056725/23210331/61af7ef0-f8fd-11e6-99a6-6d62d321b3c3.gif)
