### PR TITLE
NGINX ingress controller chart instructions

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,7 +6,7 @@ Monocular is packaged as a Helm Chart that can be found in the `/deployment/mono
 
 > **Prerequisites**
 >
-> The chart is configured and tested to be used alongside an NGINX Ingress controller. Please be sure that you have a running instance in your cluster before proceeding. You can install it by executing `helm install stable/nginx-ingress`.
+> The chart is configured and tested to be used alongside an NGINX Ingress controller. Please be sure that you have a running instance in your cluster before proceeding. More information [here](https://github.com/kubernetes/charts/tree/master/stable/nginx-ingress).
 
 Install the Monocular chart:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,9 +6,9 @@ Monocular is packaged as a Helm Chart that can be found in the `/deployment/mono
 
 > **Prerequisites**
 >
-> The chart is configured and tested to be used alongside an NGINX Ingress controller. Please be sure that you have a running instance in your cluster before proceeding. More information  [here](https://github.com/kubernetes/ingress/tree/master/controllers/nginx).
+> The chart is configured and tested to be used alongside an NGINX Ingress controller. Please be sure that you have a running instance in your cluster before proceeding. You can install it by executing `helm install stable/nginx-ingress`.
 
-Install the chart:
+Install the Monocular chart:
 
 ```
 helm install deployment/monocular


### PR DESCRIPTION
NGINX ingress controller has been merged as stable Chart so some modifications in the deployment instructions were required.

cc/ @mgoodness

https://kubeapps.com/charts/stable/nginx-ingress