### PR TITLE
fix(cache): replaces data all at once

### DIFF
--- a/src/api/data/cache/cache.go
+++ b/src/api/data/cache/cache.go
@@ -146,7 +146,7 @@ func (c *cachedCharts) Refresh() error {
 		if err != nil {
 			return err
 		}
-		c.allCharts[repo.Name] = []*models.ChartPackage{}
+		var chartsWithData []*models.ChartPackage
 		for _, chart := range charts {
 			// Extra files. Skipped if the directory exists
 			dataExists, err := charthelper.ChartDataExists(chart)
@@ -164,8 +164,9 @@ func (c *cachedCharts) Refresh() error {
 				// If we have a problem processing an image it will fallback to the default one
 				charthelper.DownloadAndProcessChartIcon(chart)
 			}
-			c.allCharts[repo.Name] = append(c.allCharts[repo.Name], chart)
+			chartsWithData = append(c.allCharts[repo.Name], chart)
 		}
+		c.allCharts[repo.Name] = chartsWithData
 	}
 	return nil
 }

--- a/src/api/data/cache/cache.go
+++ b/src/api/data/cache/cache.go
@@ -164,7 +164,7 @@ func (c *cachedCharts) Refresh() error {
 				// If we have a problem processing an image it will fallback to the default one
 				charthelper.DownloadAndProcessChartIcon(chart)
 			}
-			chartsWithData = append(c.allCharts[repo.Name], chart)
+			chartsWithData = append(chartsWithData, chart)
 		}
 		c.allCharts[repo.Name] = chartsWithData
 	}


### PR DESCRIPTION
This change replaces the in-memory cache of charts data only when a complete, updated collection of repo charts data has been remotely refreshed, instead of at the beginning of the data extraction/transformation process.

Fixes the most egregious symptoms listed in #187.