### PR TITLE
Add timeout to chart indexer

### DIFF
--- a/src/api/data/cache/cache.go
+++ b/src/api/data/cache/cache.go
@@ -158,6 +158,7 @@ func (c *cachedCharts) Refresh() error {
 
 				err := charthelper.DownloadAndExtractChartTarball(chart)
 				if err != nil {
+					fmt.Printf("Error on DownloadAndExtractChartTarball: %v\n", err)
 					// Skip chart if error extracting the tarball
 					continue
 				}

--- a/src/api/data/cache/charthelper/chart_package_helper.go
+++ b/src/api/data/cache/charthelper/chart_package_helper.go
@@ -10,9 +10,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/helm/monocular/src/api/swagger/models"
 )
+
+const defaultTimeout time.Duration = 5 * time.Second
 
 // DownloadAndExtractChartTarball the chart tar file linked by metadata.Urls and store
 // the wanted files (i.e README.md) under chartDataDir
@@ -54,7 +57,10 @@ var downloadTarball = func(chart *models.ChartPackage) error {
 
 	fmt.Printf("Downloading metadata from %s\n", source)
 	// Download tarball
-	resp, err := http.Get(source)
+	c := &http.Client{
+		Timeout: defaultTimeout,
+	}
+	resp, err := c.Get(source)
 	if err != nil {
 		return err
 	}

--- a/src/api/data/cache/charthelper/icon_helper.go
+++ b/src/api/data/cache/charthelper/icon_helper.go
@@ -76,7 +76,10 @@ func downloadIcon(chart *models.ChartPackage) error {
 	fmt.Printf("Downloading icon %s into %s\n", chart.Icon, dest)
 
 	// Download
-	resp, err := http.Get(chart.Icon)
+	c := &http.Client{
+		Timeout: defaultTimeout,
+	}
+	resp, err := c.Get(chart.Icon)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Added 5 seconds client timeout instead of relying on the server defined one. This is just part of a bigger optimization effort refs by  https://github.com/helm/monocular/issues/187

Closes https://github.com/helm/monocular/issues/138