### PR TITLE
feat(backend|frontend): Gzip and cache headers

### DIFF
--- a/deployment/monocular/templates/ui-vhost.yaml
+++ b/deployment/monocular/templates/ui-vhost.yaml
@@ -15,12 +15,9 @@ data:
 
     server {
       listen 80;
-      ##
-      # `gzip` Settings
-      ##
-
+      
       gzip on;
-      # Angular CLI already has gzipped the assets (ng build --prod --aot) 
+      # Angular CLI already has gzipped the assets (ng build --prod --aot)
       gzip_static  on;
 
       location / {

--- a/deployment/monocular/templates/ui-vhost.yaml
+++ b/deployment/monocular/templates/ui-vhost.yaml
@@ -15,6 +15,13 @@ data:
 
     server {
       listen 80;
+      ##
+      # `gzip` Settings
+      ##
+
+      gzip on;
+      # Angular CLI already has gzipped the assets (ng build --prod --aot) 
+      gzip_static  on;
 
       location / {
         try_files $uri @prerender;

--- a/src/api/glide.lock
+++ b/src/api/glide.lock
@@ -1,5 +1,5 @@
-hash: 033e69b36b9b4dcbb9d5e796f15d7e4e931ad72736f78ed911eacfc3cf4b30ed
-updated: 2017-03-01T19:50:01.574394115Z
+hash: 3cfca4aa96f086295b17280fa8a80c15c36059686f47c36a143eb0a299e8fa99
+updated: 2017-03-02T18:54:49.229096603Z
 imports:
 - name: github.com/arschles/assert
   version: bb58b908265b5931732079df03f2818bf2167ba0
@@ -57,6 +57,8 @@ imports:
   version: 59c29afe1a994eacb71c833025ca7acf874bb1da
 - name: github.com/mitchellh/mapstructure
   version: db1efb556f84b25a0a13a04aad883943538ad2e0
+- name: github.com/NYTimes/gziphandler
+  version: 6710af535839f57c687b62c4c23d649f9545d885
 - name: github.com/PuerkitoBio/purell
   version: 0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4
 - name: github.com/PuerkitoBio/urlesc
@@ -80,6 +82,10 @@ imports:
   subpackages:
   - context
   - idna
+- name: golang.org/x/sys
+  version: 76cc09b634294339fa19ec41b5f2a0b3932cea8b
+  subpackages:
+  - unix
 - name: golang.org/x/text
   version: dafb3384ad25363d928a9e97ce4ad3a2f0667e34
   subpackages:

--- a/src/api/glide.yaml
+++ b/src/api/glide.yaml
@@ -22,3 +22,4 @@ import:
   version: ~1.2.2
 - package: github.com/Sirupsen/logrus
   version: ^0.11.4
+- package: github.com/NYTimes/gziphandler

--- a/src/api/swagger/restapi/configure_monocular.go
+++ b/src/api/swagger/restapi/configure_monocular.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/NYTimes/gziphandler"
 	errors "github.com/go-openapi/errors"
 	runtime "github.com/go-openapi/runtime"
 	middleware "github.com/go-openapi/runtime/middleware"
@@ -102,7 +103,10 @@ func setupStaticFilesMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Returns static files under /static
 		if strings.Index(r.URL.Path, "/assets/") == 0 {
-			fs := http.StripPrefix("/assets/", http.FileServer(http.Dir(charthelper.DataDirBase())))
+			// 7 days cache
+			w.Header().Set("Cache-Control", "public, max-age=604800")
+			fs := http.FileServer(http.Dir(charthelper.DataDirBase()))
+			fs = http.StripPrefix("/assets/", gziphandler.GzipHandler(fs))
 			fs.ServeHTTP(w, r)
 		} else {
 			// Fallbacks to chained hander

--- a/src/api/swagger/restapi/configure_monocular.go
+++ b/src/api/swagger/restapi/configure_monocular.go
@@ -95,6 +95,7 @@ func setupMiddlewares(handler http.Handler) http.Handler {
 func setupGlobalMiddleware(handler http.Handler) http.Handler {
 	handler = setupStaticFilesMiddleware(handler)
 	handler = setupCorsMiddleware(handler)
+	handler = gziphandler.GzipHandler(handler)
 	return handler
 }
 
@@ -103,10 +104,9 @@ func setupStaticFilesMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Returns static files under /static
 		if strings.Index(r.URL.Path, "/assets/") == 0 {
-			// 7 days cache
-			w.Header().Set("Cache-Control", "public, max-age=604800")
+			w.Header().Set("Cache-Control", "public, max-age=7776000")
 			fs := http.FileServer(http.Dir(charthelper.DataDirBase()))
-			fs = http.StripPrefix("/assets/", gziphandler.GzipHandler(fs))
+			fs = http.StripPrefix("/assets/", fs)
 			fs.ServeHTTP(w, r)
 		} else {
 			// Fallbacks to chained hander


### PR DESCRIPTION
Closes https://github.com/helm/monocular/issues/204

Backend:

* Added gzip 
* Added cache headers for static files

Frontend: 

* Configured Nginx to use the pre-bundled gz files. 