### PR TITLE
feat(backend): Store chart package in cache

### DIFF
--- a/src/api/data/cache/charthelper/chart_package_helper.go
+++ b/src/api/data/cache/charthelper/chart_package_helper.go
@@ -41,7 +41,7 @@ var DownloadAndExtractChartTarball = func(chart *models.ChartPackage) error {
 }
 
 var tarballExists = func(chart *models.ChartPackage) bool {
-	_, err := os.Stat(tarballTmpPath(chart))
+	_, err := os.Stat(tarballPath(chart))
 	return err == nil
 }
 
@@ -49,7 +49,7 @@ var tarballExists = func(chart *models.ChartPackage) bool {
 // in order to extract specific files for caching
 var downloadTarball = func(chart *models.ChartPackage) error {
 	source := chart.Urls[0]
-	destination := tarballTmpPath(chart)
+	destination := tarballPath(chart)
 
 	// Create output
 	out, err := os.Create(destination)
@@ -91,7 +91,7 @@ var downloadTarball = func(chart *models.ChartPackage) error {
 var filesToKeep = []string{"README.md"}
 
 var extractFilesFromTarball = func(chart *models.ChartPackage) error {
-	tarballPath := tarballTmpPath(chart)
+	tarballPath := tarballPath(chart)
 	tarballExpandedPath, err := ioutil.TempDir(os.TempDir(), "chart")
 	if err != nil {
 		return err
@@ -135,9 +135,8 @@ var ensureChartDataDir = func(chart *models.ChartPackage) error {
 }
 
 // Temporary path used for downloaded tarball
-var tarballTmpPath = func(chart *models.ChartPackage) string {
-	splitTarURL := strings.Split(chart.Urls[0], "/")
-	return filepath.Join("/tmp", fmt.Sprintf("%s-%s", chart.Repo, splitTarURL[len(splitTarURL)-1]))
+var tarballPath = func(chart *models.ChartPackage) string {
+	return filepath.Join(chartDataDir(chart), "chart.tgz")
 }
 
 // DataDirBase is the directory used to store cached data like readme files

--- a/src/api/data/cache/charthelper/chart_package_helper_test.go
+++ b/src/api/data/cache/charthelper/chart_package_helper_test.go
@@ -69,14 +69,14 @@ func TestDownloadTarballCreatesFileInDestination(t *testing.T) {
 
 	// Mock download path
 	randomPath, _ := ioutil.TempDir(os.TempDir(), "test")
-	tarballTmpPathOrig := tarballTmpPath
-	defer func() { tarballTmpPath = tarballTmpPathOrig }()
-	tarballTmpPath = func(chart *models.ChartPackage) string {
+	tarballPathOrig := tarballPath
+	defer func() { tarballPath = tarballPathOrig }()
+	tarballPath = func(chart *models.ChartPackage) string {
 		return filepath.Join(randomPath, "myFile.tar.gz")
 	}
 	err = downloadTarball(chart)
 	assert.NoErr(t, err)
-	_, err = os.Stat(tarballTmpPath(chart))
+	_, err = os.Stat(tarballPath(chart))
 	assert.NoErr(t, err)
 }
 
@@ -84,9 +84,9 @@ func TestDownloadTarballErrorDownloading(t *testing.T) {
 	chart, err := getTestChart()
 	assert.NoErr(t, err)
 	randomPath, _ := ioutil.TempDir(os.TempDir(), "test")
-	tarballTmpPathOrig := tarballTmpPath
-	defer func() { tarballTmpPath = tarballTmpPathOrig }()
-	tarballTmpPath = func(chart *models.ChartPackage) string {
+	tarballPathOrig := tarballPath
+	defer func() { tarballPath = tarballPathOrig }()
+	tarballPath = func(chart *models.ChartPackage) string {
 		return filepath.Join(randomPath, "myFile.tar.gz")
 	}
 	// Invald protocol
@@ -105,10 +105,10 @@ func TestExtractFilesFromTarballOk(t *testing.T) {
 	ensureChartDataDir(chart)
 	assert.NoErr(t, err)
 	// Stubs
-	tarballTmpPathOrig := tarballTmpPath
-	defer func() { tarballTmpPath = tarballTmpPathOrig }()
-	tarballTmpPath = func(chart *models.ChartPackage) string {
-		path := MockedtarballTmpPath()
+	tarballPathOrig := tarballPath
+	defer func() { tarballPath = tarballPathOrig }()
+	tarballPath = func(chart *models.ChartPackage) string {
+		path := MockedtarballPath()
 		return path
 	}
 	err = extractFilesFromTarball(chart)
@@ -127,9 +127,9 @@ func TestExtractFilesFromTarballNotFound(t *testing.T) {
 	chart, err := getTestChart()
 	assert.NoErr(t, err)
 	// Stubs
-	tarballTmpPathOrig := tarballTmpPath
-	defer func() { tarballTmpPath = tarballTmpPathOrig }()
-	tarballTmpPath = func(chart *models.ChartPackage) string {
+	tarballPathOrig := tarballPath
+	defer func() { tarballPath = tarballPathOrig }()
+	tarballPath = func(chart *models.ChartPackage) string {
 		return "/does-not-exist.tar.gz"
 	}
 	err = extractFilesFromTarball(chart)
@@ -140,11 +140,11 @@ func TestExtractFilesFromTarballCantCopy(t *testing.T) {
 	chart, err := getTestChart()
 	assert.NoErr(t, err)
 	// Stubs
-	tarballTmpPathOrig := tarballTmpPath
+	tarballPathOrig := tarballPath
 	copyFileOrig := copyFile
-	defer func() { tarballTmpPath = tarballTmpPathOrig; copyFile = copyFileOrig }()
-	tarballTmpPath = func(chart *models.ChartPackage) string {
-		path := MockedtarballTmpPath()
+	defer func() { tarballPath = tarballPathOrig; copyFile = copyFileOrig }()
+	tarballPath = func(chart *models.ChartPackage) string {
+		path := MockedtarballPath()
 		return path
 	}
 
@@ -158,10 +158,10 @@ func TestReadFromCacheOk(t *testing.T) {
 	chart, err := getTestChart()
 	assert.NoErr(t, err)
 	// Stubs
-	tarballTmpPathOrig := tarballTmpPath
-	defer func() { tarballTmpPath = tarballTmpPathOrig }()
-	tarballTmpPath = func(chart *models.ChartPackage) string {
-		path := MockedtarballTmpPath()
+	tarballPathOrig := tarballPath
+	defer func() { tarballPath = tarballPathOrig }()
+	tarballPath = func(chart *models.ChartPackage) string {
+		path := MockedtarballPath()
 		return path
 	}
 	ensureChartDataDir(chart)
@@ -241,7 +241,7 @@ func TestCopyFile(t *testing.T) {
 }
 
 func TestUntar(t *testing.T) {
-	src := MockedtarballTmpPath()
+	src := MockedtarballPath()
 	dest, _ := ioutil.TempDir(os.TempDir(), "")
 	err := untar(src, dest)
 	assert.NoErr(t, err)
@@ -277,6 +277,6 @@ func getTestChart() (*models.ChartPackage, error) {
 }
 
 // Returns the test tarball path
-func MockedtarballTmpPath() string {
+func MockedtarballPath() string {
 	return filepath.Join("testdata", "drupal-0.3.0.tgz")
 }

--- a/src/api/data/cache/charthelper/chart_package_helper_test.go
+++ b/src/api/data/cache/charthelper/chart_package_helper_test.go
@@ -68,15 +68,16 @@ func TestDownloadTarballCreatesFileInDestination(t *testing.T) {
 		httpmock.NewStringResponder(200, "Mocked Response"))
 
 	// Mock download path
-	randomPath, _ := ioutil.TempDir(os.TempDir(), "test")
-	tarballPathOrig := tarballPath
-	defer func() { tarballPath = tarballPathOrig }()
-	tarballPath = func(chart *models.ChartPackage) string {
-		return filepath.Join(randomPath, "myFile.tar.gz")
+	chartDataDirOrig := chartDataDir
+	defer func() { chartDataDir = chartDataDirOrig }()
+	pathExists, _ := ioutil.TempDir(os.TempDir(), "chart")
+	chartDataDir = func(c *models.ChartPackage) string {
+		return pathExists
 	}
+
 	err = downloadTarball(chart)
 	assert.NoErr(t, err)
-	_, err = os.Stat(tarballPath(chart))
+	_, err = os.Stat(filepath.Join(chartDataDir(chart), "chart.tgz"))
 	assert.NoErr(t, err)
 }
 


### PR DESCRIPTION
* Stores the package in the cache as chart.tgz, accessible using the API

```
http://localhost:8080/assets/stable/jenkins/0.1.8/chart.tgz
```

Closes https://github.com/helm/monocular/issues/211