### PR TITLE
Concurrent updates

### DIFF
--- a/src/api/data/cache/auto_refresher.go
+++ b/src/api/data/cache/auto_refresher.go
@@ -42,7 +42,7 @@ func (r *refreshChartsData) Frequency() time.Duration {
 	return r.frequency
 }
 
-// Frequency implements the Periodic interface
+// FirstRun implements the Periodic interface
 func (r *refreshChartsData) FirstRun() bool {
 	return r.firstRun
 }

--- a/src/api/data/cache/auto_refresher.go
+++ b/src/api/data/cache/auto_refresher.go
@@ -11,6 +11,7 @@ type refreshChartsData struct {
 	chartsImplementation data.Charts
 	frequency            time.Duration
 	name                 string
+	firstRun             bool
 }
 
 // NewRefreshChartsData creates a new Periodic implementation that refreshes charts data.
@@ -18,11 +19,13 @@ func NewRefreshChartsData(
 	chartsImplementation data.Charts,
 	frequency time.Duration,
 	name string,
+	firstRun bool,
 ) jobs.Periodic {
 	return &refreshChartsData{
 		chartsImplementation: chartsImplementation,
 		frequency:            frequency,
 		name:                 name,
+		firstRun:             firstRun,
 	}
 }
 
@@ -37,6 +40,11 @@ func (r *refreshChartsData) Do() error {
 // Frequency implements the Periodic interface
 func (r *refreshChartsData) Frequency() time.Duration {
 	return r.frequency
+}
+
+// Frequency implements the Periodic interface
+func (r *refreshChartsData) FirstRun() bool {
+	return r.firstRun
 }
 
 // Name implements the Periodic interface

--- a/src/api/data/cache/auto_refresher_test.go
+++ b/src/api/data/cache/auto_refresher_test.go
@@ -1,0 +1,37 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/arschles/assert"
+	"github.com/helm/monocular/src/api/config/repos"
+)
+
+func TestNewRefreshData(t *testing.T) {
+	repos := repos.Repos{}
+	chartsImplementation := NewCachedCharts(repos)
+	// Setup background index refreshes
+	freshness := time.Duration(3600) * time.Second
+	job := NewRefreshChartsData(chartsImplementation, freshness, "test-run", false)
+	assert.Equal(t, job.Frequency(), freshness, "Frequency")
+	assert.Equal(t, job.FirstRun(), false, "First run")
+	assert.Equal(t, job.Name(), "test-run", "Name")
+	err := job.Do()
+	assert.NoErr(t, err)
+}
+
+func TestNewRefreshDataError(t *testing.T) {
+	repos := repos.Repos{
+		repos.Repo{
+			Name: "waps",
+			URL:  "./localhost",
+		},
+	}
+	chartsImplementation := NewCachedCharts(repos)
+	freshness := time.Duration(3600) * time.Second
+	job := NewRefreshChartsData(chartsImplementation, freshness, "test-run", true)
+	assert.Equal(t, job.FirstRun(), true, "First run")
+	err := job.Do()
+	assert.ExistsErr(t, err, "Error executing refresh")
+}

--- a/src/api/data/cache/cache.go
+++ b/src/api/data/cache/cache.go
@@ -127,18 +127,18 @@ func (c *cachedCharts) Search(params charts.SearchChartsParams) ([]*models.Chart
 // Refresh is the interface implementation for data.Charts
 // It refreshes cached data for all authoritative repository+chart data
 func (c *cachedCharts) Refresh() error {
-	c.rwm.Lock()
-	defer c.rwm.Unlock()
+	// New list of charts that will replace cached charts
+	var updatedCharts = make(map[string][]*models.ChartPackage)
 
 	log.WithFields(log.Fields{
 		"path": charthelper.DataDirBase(),
 	}).Info("Using cache directory")
 
 	for _, repo := range c.knownRepos {
-		// Append index.yaml
 		u, _ := url.Parse(repo.URL)
 		u.Path = path.Join(u.Path, "index.yaml")
 
+		// 1 - Download repo index
 		resp, err := http.Get(u.String())
 		if err != nil {
 			return err
@@ -148,37 +148,84 @@ func (c *cachedCharts) Refresh() error {
 		if err != nil {
 			return err
 		}
+
+		// 2 - Parse repo index
 		charts, err := helpers.ParseYAMLRepo(body, repo.Name)
 		if err != nil {
 			return err
 		}
-		var chartsWithData []*models.ChartPackage
-		for _, chart := range charts {
-			// Extra files. Skipped if the directory exists
-			dataExists, err := charthelper.ChartDataExists(chart)
-			if err != nil {
-				return err
-			}
-			if !dataExists {
-				log.WithFields(log.Fields{
-					"name":    *chart.Name,
-					"version": *chart.Version,
-				}).Info("Local cache missing")
 
-				err := charthelper.DownloadAndExtractChartTarball(chart)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"error": err,
-					}).Error("Error on DownloadAndExtractChartTarball")
-					// Skip chart if error extracting the tarball
-					continue
-				}
-				// If we have a problem processing an image it will fallback to the default one
-				charthelper.DownloadAndProcessChartIcon(chart)
-			}
-			chartsWithData = append(chartsWithData, chart)
+		// 3 - Process elements in index
+		var chartsWithData []*models.ChartPackage
+		// Buffered channel
+		ch := make(chan chanItem, len(charts))
+		// 3.1 - parallellize processing
+		for _, chart := range charts {
+			go processChartMetadata(chart, ch)
 		}
-		c.allCharts[repo.Name] = chartsWithData
+		// 3.2 Channel drain
+		for range charts {
+			it := <-ch
+			// Only append the ones that have not failed
+			if it.err == nil {
+				chartsWithData = append(chartsWithData, it.chart)
+			}
+		}
+		updatedCharts[repo.Name] = chartsWithData
 	}
+
+	// 4 - Update the stored cache with the new elements if everything went well
+	c.rwm.Lock()
+	c.allCharts = updatedCharts
+	defer c.rwm.Unlock()
 	return nil
+}
+
+// Represents every element processed in paralell
+type chanItem struct {
+	chart *models.ChartPackage
+	err   error
+}
+
+// Counting semaphore, 25 downloads max in paralell
+var tokens = make(chan struct{}, 25)
+
+func processChartMetadata(chart *models.ChartPackage, out chan chanItem) {
+	tokens <- struct{}{}
+	// Semaphore control channel
+	defer func() {
+		<-tokens
+	}()
+
+	var it chanItem
+	it.chart = chart
+
+	// Extra files. Skipped if the directory exists
+	dataExists, err := charthelper.ChartDataExists(chart)
+	if err != nil {
+		it.err = err
+		out <- it
+		return
+	}
+
+	if !dataExists {
+		log.WithFields(log.Fields{
+			"name":    *chart.Name,
+			"version": *chart.Version,
+		}).Info("Local cache missing")
+
+		err := charthelper.DownloadAndExtractChartTarball(chart)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error": err,
+			}).Error("Error on DownloadAndExtractChartTarball")
+			// Skip chart if error extracting the tarball
+			it.err = err
+			out <- it
+			return
+		}
+		// If we have a problem processing an image it will fallback to the default one
+		charthelper.DownloadAndProcessChartIcon(chart)
+	}
+	out <- it
 }

--- a/src/api/data/cache/cache.go
+++ b/src/api/data/cache/cache.go
@@ -159,6 +159,8 @@ func (c *cachedCharts) Refresh() error {
 		var chartsWithData []*models.ChartPackage
 		// Buffered channel
 		ch := make(chan chanItem, len(charts))
+		defer close(ch)
+
 		// 3.1 - parallellize processing
 		for _, chart := range charts {
 			go processChartMetadata(chart, ch)

--- a/src/api/data/cache/cache.go
+++ b/src/api/data/cache/cache.go
@@ -190,7 +190,7 @@ type chanItem struct {
 // Counting semaphore, 25 downloads max in paralell
 var tokens = make(chan struct{}, 25)
 
-func processChartMetadata(chart *models.ChartPackage, out chan chanItem) {
+func processChartMetadata(chart *models.ChartPackage, out chan<- chanItem) {
 	tokens <- struct{}{}
 	// Semaphore control channel
 	defer func() {

--- a/src/api/data/cache/cache.go
+++ b/src/api/data/cache/cache.go
@@ -177,7 +177,7 @@ func (c *cachedCharts) Refresh() error {
 	// 4 - Update the stored cache with the new elements if everything went well
 	c.rwm.Lock()
 	c.allCharts = updatedCharts
-	defer c.rwm.Unlock()
+	c.rwm.Unlock()
 	return nil
 }
 

--- a/src/api/data/cache/charthelper/chart_package_helper.go
+++ b/src/api/data/cache/charthelper/chart_package_helper.go
@@ -251,6 +251,7 @@ func ReadmeStaticUrl(chart *models.ChartPackage, prefix string) string {
 	path := filepath.Join(chartDataDir(chart), "README.md")
 	return staticUrl(path, prefix)
 }
+
 func staticUrl(path, prefix string) string {
 	return strings.Replace(path, DataDirBase(), prefix, 1)
 }

--- a/src/api/data/cache/charthelper/chart_package_helper_test.go
+++ b/src/api/data/cache/charthelper/chart_package_helper_test.go
@@ -257,7 +257,14 @@ func TestUntar(t *testing.T) {
 	notValidFile, _ := ioutil.TempFile(os.TempDir(), "")
 	err = untar(notValidFile.Name(), dest)
 	assert.ExistsErr(t, err, "SRC does not exist")
+}
 
+func TestReadmeStaticURL(t *testing.T) {
+	chart, err := getTestChart()
+	assert.NoErr(t, err)
+	res := ReadmeStaticUrl(chart, "prefix")
+	readmePath := filepath.Join(chartDataDir(chart), "README.md")
+	assert.Equal(t, res, staticUrl(readmePath, "prefix"), "Readme file ")
 }
 
 // Auxiliar

--- a/src/api/jobs/jobs.go
+++ b/src/api/jobs/jobs.go
@@ -13,6 +13,7 @@ type Periodic interface {
 	Do() error
 	Frequency() time.Duration
 	Name() string
+	FirstRun() bool
 }
 
 // PeriodicCanceller will cancel one or more Periodic jobs
@@ -26,11 +27,13 @@ func DoPeriodic(pSlice []Periodic) PeriodicCanceller {
 	for _, p := range pSlice {
 		go func(p Periodic) {
 			// execute once at the beginning
-			err := p.Do()
-			if err != nil {
-				log.Printf("periodic job ran and returned error (%s)", err)
+			if p.FirstRun() {
+				err := p.Do()
+				if err != nil {
+					log.Printf("periodic job ran and returned error (%s)", err)
+				}
+				log.Printf("periodic job %s ran", p.Name())
 			}
-			log.Printf("periodic job %s ran", p.Name())
 			ticker := time.NewTicker(p.Frequency())
 			for {
 				select {

--- a/src/api/jobs/jobs_test.go
+++ b/src/api/jobs/jobs_test.go
@@ -9,11 +9,12 @@ import (
 )
 
 type testPeriodic struct {
-	t    *testing.T
-	err  error
-	i    int
-	freq time.Duration
-	name string
+	t        *testing.T
+	err      error
+	i        int
+	freq     time.Duration
+	name     string
+	firstRun bool
 }
 
 func (t *testPeriodic) Do() error {
@@ -30,9 +31,13 @@ func (t testPeriodic) Name() string {
 	return t.name
 }
 
+func (t testPeriodic) FirstRun() bool {
+	return t.firstRun
+}
+
 func TestDoPeriodic(t *testing.T) {
-	interval := time.Duration(3000) * time.Millisecond
-	p := &testPeriodic{t: t, err: nil, freq: interval, name: "test-periodic-job"}
+	interval := time.Duration(500) * time.Millisecond
+	p := &testPeriodic{t: t, err: nil, freq: interval, name: "test-periodic-job", firstRun: true}
 	canceller := DoPeriodic([]Periodic{p})
 	time.Sleep(interval / 2) // wait a little while for the goroutine to call the job once
 	assert.True(t, p.i == 1, "the periodic wasn't called once")
@@ -44,12 +49,23 @@ func TestDoPeriodic(t *testing.T) {
 }
 
 func TestDoPeriodicWithError(t *testing.T) {
-	interval := time.Duration(3000) * time.Millisecond
-	p := &testPeriodic{t: t, err: errors.New("Do() crashes"), freq: interval, name: "test-periodic-job"}
+	interval := time.Duration(500) * time.Millisecond
+	p := &testPeriodic{t: t, err: errors.New("Do() crashes"), freq: interval, name: "test-periodic-job", firstRun: true}
 	canceller := DoPeriodic([]Periodic{p})
 	time.Sleep(interval / 2) // wait a little while for the goroutine to call the job once
 	assert.True(t, p.i == 1, "the periodic wasn't called once")
 	time.Sleep(interval)
 	assert.True(t, p.i == 2, "the periodic wasn't called twice")
+	canceller()
+}
+
+func TestDoPeriodicNoFirstRun(t *testing.T) {
+	interval := time.Duration(500) * time.Millisecond
+	p := &testPeriodic{t: t, err: nil, freq: interval, name: "test-periodic-job2", firstRun: false}
+	canceller := DoPeriodic([]Periodic{p})
+	time.Sleep(interval / 2) // wait a little while for the goroutine to call the job once
+	assert.Equal(t, p.i, 0, "the periodic has not being called")
+	time.Sleep(interval)
+	assert.Equal(t, p.i, 1, "the periodic has being called once")
 	canceller()
 }

--- a/src/api/swagger/restapi/configure_monocular.go
+++ b/src/api/swagger/restapi/configure_monocular.go
@@ -44,10 +44,14 @@ func configureAPI(api *operations.MonocularAPI) http.Handler {
 	}
 	// configure the api here
 	chartsImplementation := cache.NewCachedCharts(config.Repos)
+	// Run foreground repository refresh
+	chartsImplementation.Refresh()
+	// Setup background index refreshes
 	freshness := time.Duration(3600) * time.Second
-	periodicRefresh := cache.NewRefreshChartsData(chartsImplementation, freshness, "refresh-charts")
+	periodicRefresh := cache.NewRefreshChartsData(chartsImplementation, freshness, "refresh-charts", false)
 	toDo := []jobs.Periodic{periodicRefresh}
 	jobs.DoPeriodic(toDo)
+
 	api.ServeError = errors.ServeError
 	helmClient := helmclient.NewHelmClient()
 


### PR DESCRIPTION
Refs https://github.com/helm/monocular/issues/187

This PR aims to improve the importation times by:

* Use a buffered channel allowing a max of 25 concurrent downloads (the number is based on some empirical tests, imports started failing over 75, but 25+ workers made minor import time improvements) and assets processing.
* Use exclusive locking only at the moment of the cache update (Import does not seem to depend in any existing data). Allowing the API to keep accepting requests during importation.
* During import, store the new indexed data in a new map, transferring it as a whole if everything went well at the end of the importation.
* Moved initial refresh() foreground since now it does not depend on the Mutex
* Modified periodic package to support first run flag. Disabled by default once the app bootstraps.