### PR TITLE
SEO improvements

### DIFF
--- a/src/ui/src/app/app.module.ts
+++ b/src/ui/src/app/app.module.ts
@@ -20,6 +20,7 @@ import { ReposService } from './shared/services/repos.service';
 import { ConfigService } from './shared/services/config.service';
 import { MenuService } from './shared/services/menu.service';
 import { DialogsService } from './shared/services/dialogs.service';
+import { SeoService } from './shared/services/seo.service';
 
 /* Components */
 import { AppComponent } from './app.component';
@@ -102,10 +103,11 @@ const metaConfig: MetaConfig = {
     ReposService,
     ConfigService,
     MenuService,
+    SeoService,
     DialogsService
   ],
   entryComponents: [
-    ConfirmDialog,
+    ConfirmDialog
   ],
   bootstrap: [AppComponent]
 })

--- a/src/ui/src/app/app.routing.ts
+++ b/src/ui/src/app/app.routing.ts
@@ -12,13 +12,7 @@ import { DeploymentComponent } from './deployment/deployment.component';
 const appRoutes: Routes = [
   {
     path: '',
-    component: ChartIndexComponent,
-    data: {
-      meta: {
-        title: 'KubeApps: Discover & launch great Kubernetes-ready apps',
-        description: 'KubeApps is a platform for discovering & launching great Kubernetes-ready apps. Browse the catalog and deploy your applications in your Kubernetes cluster'
-      }
-    }
+    component: ChartIndexComponent
   },
   {
     path: 'deployments',

--- a/src/ui/src/app/app.routing.ts
+++ b/src/ui/src/app/app.routing.ts
@@ -12,7 +12,13 @@ import { DeploymentComponent } from './deployment/deployment.component';
 const appRoutes: Routes = [
   {
     path: '',
-    component: ChartIndexComponent
+    component: ChartIndexComponent,
+    data: {
+      meta: {
+        title: 'KubeApps: Discover & launch great Kubernetes-ready apps',
+        description: 'KubeApps is a platform for discovering & launching great Kubernetes-ready apps. Browse the catalog and deploy your applications in your Kubernetes cluster'
+      }
+    }
   },
   {
     path: 'deployments',

--- a/src/ui/src/app/app.routing.ts
+++ b/src/ui/src/app/app.routing.ts
@@ -40,12 +40,7 @@ const appRoutes: Routes = [
   },
   {
     path: 'charts',
-    component: ChartsComponent,
-    data: {
-      meta: {
-        title: 'All charts'
-      }
-    }
+    component: ChartsComponent
   },
   {
     path: 'charts/search',
@@ -53,12 +48,7 @@ const appRoutes: Routes = [
   },
   {
     path: 'charts/:repo',
-    component: ChartsComponent,
-    data: {
-      meta: {
-        title: 'All charts by repository'
-      }
-    }
+    component: ChartsComponent
   },
   {
     path: 'charts/:repo/:chartName',

--- a/src/ui/src/app/chart-details/chart-details.component.ts
+++ b/src/ui/src/app/chart-details/chart-details.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
 import { ChartsService } from '../shared/services/charts.service';
 import { Chart } from '../shared/models/chart';
-import { MetaService } from 'ng2-meta';
+import { SeoService } from '../shared/services/seo.service';
 import { ConfigService } from '../shared/services/config.service';
 
 @Component({
@@ -21,7 +21,7 @@ export class ChartDetailsComponent implements OnInit {
     private route: ActivatedRoute,
     private chartsService: ChartsService,
     private config: ConfigService,
-    private metaService: MetaService
+    private seo: SeoService
   ) { }
 
   ngOnInit() {
@@ -40,39 +40,20 @@ export class ChartDetailsComponent implements OnInit {
   }
 
   /**
-   * Content for the title version tag
-   *
-   * @return {string} Title to display in the site
-   */
-  contentTitleVersion(capitalize = true): string {
-    if (this.titleVersion.length > 0) {
-      return this.chart.attributes.name;
-    } else if (capitalize) {
-      return `Latest ${this.chart.attributes.name}`;
-    } else {
-      return `latest ${this.chart.attributes.name}`;
-    }
-  }
-
-  /**
-   * Get the description content for the metatag
-   *
-   * @return {string} Description to add to the metatags
-   */
-  descriptionContent(): string {
-    let title: string = this.contentTitleVersion(false);
-    return `Deploy ${title} in Kubernetes. ${this.chart.attributes.name}
-      is a ${this.chart.attributes.description}`;
-  }
-
-  /**
    * Update the metatags with the name and the description of the application.
    */
   updateMetaTags(): void {
-    let title: string = this.contentTitleVersion();
-    this.metaService.setTitle(title, ` | ${this.config.appName}`);
-    this.metaService.setTag('description', this.descriptionContent());
-    this.metaService.setTag('og:title', title);
-    this.metaService.setTag('og:description', this.descriptionContent());
+    if (this.titleVersion.length > 0) {
+      this.seo.setMetaTags('detailsWithVersion', {
+        name: this.chart.attributes.name,
+        description: this.chart.attributes.description,
+        version: this.titleVersion
+      });
+    } else {
+      this.seo.setMetaTags('details', {
+        name: this.chart.attributes.name,
+        description: this.chart.attributes.description
+      });
+    }
   }
 }

--- a/src/ui/src/app/chart-details/chart-details.component.ts
+++ b/src/ui/src/app/chart-details/chart-details.component.ts
@@ -44,12 +44,25 @@ export class ChartDetailsComponent implements OnInit {
    *
    * @return {string} Title to display in the site
    */
-  contentTitleVersion(): string {
+  contentTitleVersion(capitalize = true): string {
     if (this.titleVersion.length > 0) {
-      return `${this.chart.attributes.name} ${this.titleVersion}`;
-    } else {
       return this.chart.attributes.name;
+    } else if (capitalize) {
+      return `Latest ${this.chart.attributes.name}`;
+    } else {
+      return `latest ${this.chart.attributes.name}`;
     }
+  }
+
+  /**
+   * Get the description content for the metatag
+   *
+   * @return {string} Description to add to the metatags
+   */
+  descriptionContent(): string {
+    let title: string = this.contentTitleVersion(false);
+    return `Deploy ${title} in Kubernetes. ${this.chart.attributes.name}
+      is a ${this.chart.attributes.description}`;
   }
 
   /**
@@ -58,8 +71,8 @@ export class ChartDetailsComponent implements OnInit {
   updateMetaTags(): void {
     let title: string = this.contentTitleVersion();
     this.metaService.setTitle(title, ` | ${this.config.appName}`);
-    this.metaService.setTag('description', this.chart.attributes.description);
+    this.metaService.setTag('description', this.descriptionContent());
     this.metaService.setTag('og:title', title);
-    this.metaService.setTag('og:description', this.chart.attributes.description);
+    this.metaService.setTag('og:description', this.descriptionContent());
   }
 }

--- a/src/ui/src/app/chart-index/chart-index.component.ts
+++ b/src/ui/src/app/chart-index/chart-index.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ChartsService } from '../shared/services/charts.service';
 import { Chart } from '../shared/models/chart';
-import { ConfigService } from '../shared/services/config.service';
-import { MetaService } from 'ng2-meta';
+import { SeoService } from '../shared/services/seo.service';
 
 @Component({
   selector: 'app-chart-index',
@@ -16,13 +15,12 @@ export class ChartIndexComponent implements OnInit {
 
   constructor(
     private chartsService: ChartsService,
-    private config: ConfigService,
-    private metaService: MetaService
+    private seo: SeoService
   ) {}
 
   ngOnInit() {
 		this.loadCharts();
-    this.updateMetaTags();
+    this.seo.setMetaTags('index');
   }
 
   loadCharts(): void {
@@ -31,11 +29,5 @@ export class ChartIndexComponent implements OnInit {
       this.charts = charts;
       this.totalChartsNumber = charts.length;
     });
-  }
-
-  updateMetaTags(): void {
-    let title: string = this.config.appName;
-    this.metaService.setTitle(title, "");
-    this.metaService.setTag('og:title', title);
   }
 }

--- a/src/ui/src/app/chart-search/chart-search.component.ts
+++ b/src/ui/src/app/chart-search/chart-search.component.ts
@@ -3,6 +3,7 @@ import { ChartsService } from '../shared/services/charts.service';
 import { MetaService } from 'ng2-meta';
 import { Chart } from '../shared/models/chart';
 import { ConfigService } from '../shared/services/config.service';
+import { SeoService } from '../shared/services/seo.service';
 
 import { ActivatedRoute } from '@angular/router';
 import { Observable }         from 'rxjs/Observable';
@@ -22,7 +23,7 @@ export class ChartSearchComponent implements OnInit {
     private route: ActivatedRoute,
     private chartsService: ChartsService,
     private config: ConfigService,
-    private metaService: MetaService
+    private seo: SeoService
   ) { }
 
   ngOnInit() {
@@ -35,7 +36,7 @@ export class ChartSearchComponent implements OnInit {
       });
 
     // Update meta tags
-    this.updateMetaTags();
+    this.seo.setMetaTags('search', { search: this.query });
   }
 
   searchCharts(q: string): void {
@@ -51,14 +52,5 @@ export class ChartSearchComponent implements OnInit {
     } else {
       return `"${this.query}" did not return any results`;
     }
-  }
-
-  /**
-   * Update the metatags with the string we are looking for.
-   */
-  updateMetaTags(): void {
-    let title: string = `Results for "${this.query}"`;
-    this.metaService.setTitle(title, ` | ${this.config.appName}`);
-    this.metaService.setTag('og:title', title);
   }
 }

--- a/src/ui/src/app/shared/seo.data.ts
+++ b/src/ui/src/app/shared/seo.data.ts
@@ -9,17 +9,17 @@ export default {
   },
   search: {
     title: 'Results for "{ search }" Kubernetes-ready applications',
-    description: 'Results for "{ search }" in the KubeApps catalog of Kubernetes-ready applications. ' +
+    description: 'Results for "{ search }" in the { appName } catalog of Kubernetes-ready applications. ' +
                  'Deploy all apps you need in your infrastructure or the cloud'
   },
   charts: {
     title: 'Kubernetes-ready applications catalog',
-    description: 'Browse the KubeApps catalog of Kubernetes-ready apps. Deploy all apps you need ' +
+    description: 'Browse the { appName } catalog of Kubernetes-ready apps. Deploy all apps you need ' +
                  'in your infrastructure or the cloud with a command using Helm Charts'
   },
   repoCharts: {
     title: '{ repo } repository of Kubernetes-ready applications',
-    description: 'Browse the KubeApps catalog of the { repo } repository of Kubernetes-ready apps. ' +
+    description: 'Browse the { appName } catalog of the { repo } repository of Kubernetes-ready apps. ' +
                  'Deploy all apps you need in your infrastructure or the cloud with a command using ' +
                  'Helm Charts'
   },

--- a/src/ui/src/app/shared/seo.data.ts
+++ b/src/ui/src/app/shared/seo.data.ts
@@ -1,0 +1,10 @@
+/**
+ * This files contains the titles and descriptions for the different sections of the site
+ */
+export default {
+  index: {
+    title: '{ appName }: Discover & launch great Kubernetes-ready apps',
+    description: '{ appName } is a platform for discovering & launching great Kubernetes-ready' +
+                 'apps. Browse the catalog and deploy your applications in your Kubernetes cluster'
+  }
+}

--- a/src/ui/src/app/shared/seo.data.ts
+++ b/src/ui/src/app/shared/seo.data.ts
@@ -6,5 +6,29 @@ export default {
     title: '{ appName }: Discover & launch great Kubernetes-ready apps',
     description: '{ appName } is a platform for discovering & launching great Kubernetes-ready' +
                  'apps. Browse the catalog and deploy your applications in your Kubernetes cluster'
+  },
+  search: {
+    title: 'Results for "{ search }" Kubernetes-ready applications',
+    description: 'Results for "{ search }" in the KubeApps catalog of Kubernetes-ready applications. ' +
+                 'Deploy all apps you need in your infrastructure or the cloud'
+  },
+  charts: {
+    title: 'Kubernetes-ready applications catalog',
+    description: 'Browse the KubeApps catalog of Kubernetes-ready apps. Deploy all apps you need ' +
+                 'in your infrastructure or the cloud with a command using Helm Charts'
+  },
+  repoCharts: {
+    title: '{ repo } repository of Kubernetes-ready applications',
+    description: 'Browse the KubeApps catalog of the { repo } repository of Kubernetes-ready apps. ' +
+                 'Deploy all apps you need in your infrastructure or the cloud with a command using ' +
+                 'Helm Charts'
+  },
+  details: {
+    title: 'Latest { name } for Kubernetes',
+    description: 'Deploy the latest { name } in Kubernetes. { description }'
+  },
+  detailsWithVersion: {
+    title: '{ name } { version } for Kubernetes',
+    description: 'Deploy the { name } { version } in Kubernetes. { description }'
   }
 }

--- a/src/ui/src/app/shared/services/config.service.ts
+++ b/src/ui/src/app/shared/services/config.service.ts
@@ -12,7 +12,7 @@ export class ConfigService {
   constructor() {
     var overrides: any = {}
     if (window["monocular"]) {
-      overrides = window["monocular"]["overrides"] || {}
+      overrides = window["monocular"]["overrides"] || {};
     }
 
     this.backendHostname = overrides.backendHostname || "http://localhost:8080";

--- a/src/ui/src/app/shared/services/seo.service.ts
+++ b/src/ui/src/app/shared/services/seo.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@angular/core';
+import { ConfigService } from './config.service';
+import { MetaService } from 'ng2-meta';
+
+// Import SEO data
+import SeoData from '../seo.data';
+
+/* TODO, This is a mocked class. */
+@Injectable()
+export class SeoService {
+  // Current name of the application
+  appName: string = '';
+
+  constructor(
+    private config: ConfigService,
+    private metaService: MetaService
+  ) {
+    this.appName = config.appName;
+  }
+
+  /**
+   * Return the SEO data for the metaTags of the current page
+   */
+  getMetaContent(page, data = {}) {
+    let metadata = Object.assign({}, SeoData[page]);
+    // Regex of custom data
+    let regex = /{ (\w+) }/gi;
+    let match;
+
+    Object.keys(metadata).forEach(key => {
+      while (match = regex.exec(metadata[key])) {
+        if (match[1] === 'appName') {
+          metadata[key] = metadata[key].replace(match[0], this.appName);
+        } else {
+          metadata[key] = metadata[key].replace(match[0], data[match[1]]);
+        }
+      }
+    });
+
+    return metadata;
+  }
+
+  /**
+   * Set the given tags in the head of the page through MetaService
+   */
+  setMetaTags(page, data = {}) {
+    let content = this.getMetaContent(page, data);
+    let suffix = page === 'index' ? '' : ` | ${this.appName}`;
+    // Set tags
+    this.metaService.setTitle(content.title, suffix);
+    this.metaService.setTag('description', content.description);
+    this.metaService.setTag('og:title', content.title);
+    this.metaService.setTag('og:description', content.description);
+
+    // Check if we can add the image
+    if (data['image'] !== undefined) {
+      this.metaService.setTag('og:image', data['image']);
+    }
+  }
+}

--- a/src/ui/src/app/shared/services/seo.service.ts
+++ b/src/ui/src/app/shared/services/seo.service.ts
@@ -52,7 +52,7 @@ export class SeoService {
     this.metaService.setTag('og:title', content.title);
     this.metaService.setTag('og:description', content.description);
 
-    // Check if we can add the image
+    // Check if we can set the image
     if (data['image'] !== undefined) {
       this.metaService.setTag('og:image', data['image']);
     }


### PR DESCRIPTION
Currently, every component set the titles and descriptions of the pages. This means, these values are distributed over the project, so we don't have a common point with this information.

To solve this, I've create a new service that configures the metatags for a given page. It allows you to use placeholders that will be overridden by the provided information from the component. The titles and description are located in `src/ui/src/app/shared/seo.data.ts`. As you can see, there are several placeholders in the code (Ex. `{ repo }`).

To update the metatags, you only need to call the `setMetaTags(page, values)` method of the service.