### PR TITLE
Bump health check for initial delay for monocular-api

### DIFF
--- a/deployment/monocular/templates/api-deployment.yaml
+++ b/deployment/monocular/templates/api-deployment.yaml
@@ -23,13 +23,13 @@ spec:
           httpGet:
             path: /healthz
             port: {{ .Values.api.service.internalPort }}
-          initialDelaySeconds: 60
+          initialDelaySeconds: 180
           timeoutSeconds: 10
         readinessProbe:
           httpGet:
             path: /healthz
             port: {{ .Values.api.service.internalPort }}
-          initialDelaySeconds: 30
+          initialDelaySeconds: 90
           timeoutSeconds: 5
         volumeMounts:
           - name: config

--- a/deployment/monocular/templates/api-deployment.yaml
+++ b/deployment/monocular/templates/api-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           httpGet:
             path: /healthz
             port: {{ .Values.api.service.internalPort }}
-          initialDelaySeconds: 90
+          initialDelaySeconds: 30
           timeoutSeconds: 5
         volumeMounts:
           - name: config


### PR DESCRIPTION
I'm running monocular under minikube (under xhyve) on a less than powerful 8GB MacBook Air.

After deploying tiller & nginx-ingress I was able to deploy monocular using:
helm install deployment/monocular

On my system the monocular-api pod gets killed before it has started up by the default health check determining the pod is unhealthy, resulting in a slow motion crash-loop. 

From looking at the logs, the monocular-api pod is not unhealthy it's just doing the first (synchronous) poll of the stable repo which takes longer than the initial health check timeout (60 seconds.)

This PR hacks around the problem by upping the initial health check timeout. A proper fix would probably make the initial poll asynchronous or implement a more sophisticated set of health checks.