### PR TITLE
Make initialDelaySeconds of livenessProbe for monocular-api configurable

### DIFF
--- a/deployment/monocular/Chart.yaml
+++ b/deployment/monocular/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Monocular is a search and discovery front end for Helm Charts Repositories.
 name: monocular
-version: 0.1.0
+version: 0.2.0

--- a/deployment/monocular/templates/api-deployment.yaml
+++ b/deployment/monocular/templates/api-deployment.yaml
@@ -23,7 +23,7 @@ spec:
           httpGet:
             path: /healthz
             port: {{ .Values.api.service.internalPort }}
-          initialDelaySeconds: 180
+          initialDelaySeconds: {{ .Values.api.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: 10
         readinessProbe:
           httpGet:

--- a/deployment/monocular/values.yaml
+++ b/deployment/monocular/values.yaml
@@ -19,6 +19,8 @@ api:
     requests:
       cpu: 100m
       memory: 128Mi
+  livenessProbe:
+    initialDelaySeconds: 180
   config:
     repos:
       # Official repositories


### PR DESCRIPTION
Hi,

my PR "extends" #239 as it allows the configuration of the `initialDelaySeconds` value for the monocular-api's `livenessProbe` (instead of a fixed value).

As the number of available Helm charts in the stable/incubator projects is growing (and as of adding multiple own repositories to Monocular), the monocular-api needs to download, extract and investigate more and more tarballs from the Helm repository buckets. Especially when it comes to multiple versions per chart these preprocessing step takes even longer.

Due to that, a hard-coded value for the `initialDelaySeconds` limits the number and size of repositories which can be handled by Monocular.

Therefore, as users have the list of repositories under control, they also need to have the `initialDelaySeconds` under control.

Thank you!
Best regards,
Rafael