### PR TITLE
Provide clickable urls on deployment status page by parsing Service strings

### DIFF
--- a/src/ui/src/app/deployment/deployment.component.html
+++ b/src/ui/src/app/deployment/deployment.component.html
@@ -38,6 +38,12 @@
               <md-icon md-list-avatar svgIcon="info-outline"></md-icon>
               <h4 md-line>Status</h4>
               <p md-line>{{ deployment.attributes.status }}</p>
+            </md-list-item><md-list-item>
+              <md-icon md-list-avatar svgIcon="info-outline"></md-icon>
+              <h4 md-line>URL</h4>
+              <p md-line>
+                <a *ngFor="let url of deployment.attributes.urls" href="{{url}}" target="_blank"> {{url}}</a>
+              </p>
             </md-list-item>
             <md-list-item>
               <md-icon md-list-avatar svgIcon="schedule"></md-icon>

--- a/src/ui/src/app/deployment/deployment.component.ts
+++ b/src/ui/src/app/deployment/deployment.component.ts
@@ -49,58 +49,13 @@ export class DeploymentComponent implements OnInit {
 
   }
 
-  /**
-   * Prepare the resources for displaying in the UI.
-   *
-   * TODO: In the future, the backend will provide this information
-   */
-  loadResources(deployment: Deployment): any {
-    let elements = deployment.attributes.resources.split('=='),
-      resources = [];
-
-    // Remove first element
-    elements.shift();
-
-    // Regex
-    let nameRegex = /^> [\w\d\s\/]+\/(\w+)+/;
-
-    elements.forEach(el => {
-      let lines = el.split("\n");
-
-      // Name
-      let name = nameRegex.exec(lines.shift())[1];
-      let headers = lines.shift().split(/\s+/);
-      let services = [];
-
-      // Remaining lines
-      lines.forEach(line => {
-        if (line !== ''){
-          let values = line.split(/\s+/);
-          let service = {};
-
-          values.forEach((value, i) => {
-            service[headers[i]] = value;
-          });
-
-          // Add to the array
-          services.push(service);
-        }
-      });
-
-      // Build the resource
-      resources.push({ name, services });
-    });
-
-    return resources;
-  }
-
   loadDeployment(deploymentName: string): void {
     this.deploymentsService.getDeployment(deploymentName)
     .finally(()=> {
       this.loading = false;
     }).subscribe(deployment => {
       this.deployment = deployment;
-      this.resources = this.loadResources(deployment);
+      this.resources = this.deploymentsService.loadResources(deployment);
     })
   }
 

--- a/src/ui/src/app/shared/models/deployment.ts
+++ b/src/ui/src/app/shared/models/deployment.ts
@@ -13,4 +13,5 @@ class DeploymentAttributes {
   updated: Date;
   notes: string;
   resources: string;
+  urls: string[];
 }


### PR DESCRIPTION
I really like monocular. However it's missing a major usability feature of being able to visit deployed services. This implements that.

I'm sorry I'm parsing a text string. I had to do this because there is no structured status data being passed from tiller. I view this as an intermediate solution until there is a yaml-output equivalent of helm status.

<img width="1029" alt="screen shot 2017-04-28 at 2 28 50 pm" src="https://cloud.githubusercontent.com/assets/857083/25586995/dd36b0fa-2e56-11e7-89ab-60d75adccec5.png">
