### PR TITLE
Improve tiller communication to support RBAC

### DIFF
--- a/src/api/data/helm/client/client.go
+++ b/src/api/data/helm/client/client.go
@@ -59,7 +59,7 @@ func (c *helmClient) initialize() (*helm.Client, error) {
 	client := helm.NewClient(helm.Host(tillerHost))
 	// test connection
 	if _, err := client.GetVersion(); err != nil {
-		return nil, errors.New("Failed to connect to Tiller, are you sure it is installed?")
+		return nil, errors.New("failed to connect to Tiller, are you sure it is installed?")
 	}
 
 	return client, nil


### PR DESCRIPTION
- removes querying the K8S API to check if tiller is installed
- removes attempt to install tiller (this should be handled by the
  cluster admin as it requires setting up service accounts and roles in
  RBAC environments)
- only accesses the K8S API if tillerPortForward setting is enabled