### PR TITLE
Update travis to always run repo-sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,7 @@ after_success:
       docker push bitnami/monocular-api
       docker push bitnami/monocular-ui
 
-      if [[ -n "$TRAVIS_TAG" ]]; then
-        bash ./scripts/repo-sync.sh true
-      fi
+      ./scripts/repo-sync.sh
     fi
   - bash <(curl -s https://codecov.io/bash)
 

--- a/scripts/repo-sync.sh
+++ b/scripts/repo-sync.sh
@@ -101,7 +101,7 @@ fi
 
 # Skip repository sync if chart already exists in index
 CHART_VERSION=$(grep '^version:' $CHART_PATH/Chart.yaml | awk '{print $2}')
-if ! grep -q "version: $CHART_VERSION" $BUILD_DIR/index.yaml; then
+if grep -q "version: $CHART_VERSION" $BUILD_DIR/index.yaml; then
   log "Chart version $CHART_VERSION already exists... skipping"
   exit 0
 fi


### PR DESCRIPTION
This will ensure that updates to the chart source (indepdendent to
app/docker image updates) are published to the chart repository.

This commit also fixes a bug in the repo-sync script to ensure existing
versions are correctly skipped.