### PR TITLE
fix default URLs for stable/incubator repos

### DIFF
--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -3,10 +3,10 @@
 repos:
   # Official repositories
   - name: stable
-    url: http://storage.googleapis.com/kubernetes-charts
+    url: https://kubernetes-charts.storage.googleapis.com
     source: https://github.com/kubernetes/charts/tree/master/stable
   - name: incubator
-    url: http://storage.googleapis.com/kubernetes-charts-incubator
+    url: https://kubernetes-charts-incubator.storage.googleapis.com
     source: https://github.com/kubernetes/charts/tree/master/incubator
   # Add your own repository
   #- name: my-repo-name

--- a/src/api/config/repos/repos.go
+++ b/src/api/config/repos/repos.go
@@ -31,8 +31,8 @@ var official = Repos{
 	},
 	Repo{
 		Name:   "incubator",
-		URL:    "http://storage.googleapis.com/kubernetes-charts-incubator",
-		Source: "https://kubernetes-charts-incubator.storage.googleapis.com",
+		URL:    "https://kubernetes-charts-incubator.storage.googleapis.com",
+		Source: "https://github.com/kubernetes/charts/tree/master/incubator",
 	},
 }
 


### PR DESCRIPTION
The incubator source was incorrectly set to the repo url rather than github.
The default stable and incubator repo urls are updated to the subdomain https variants in the source and example configuration. The chart is already configured to use the correct URLs.