### PR TITLE
Move all ingress annotations to values

### DIFF
--- a/deployment/monocular/Chart.yaml
+++ b/deployment/monocular/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: monocular
 description: Monocular is a search and discovery front end for Helm Charts Repositories.
-version: 0.4.3
+version: 0.4.4
 appVersion: v0.2.1
 home: https://github.com/helm/monocular
 sources:

--- a/deployment/monocular/templates/ingress.yaml
+++ b/deployment/monocular/templates/ingress.yaml
@@ -7,8 +7,6 @@ metadata:
   {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
-    ingress.kubernetes.io/rewrite-target: /
-    kubernetes.io/ingress.class: nginx
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/deployment/monocular/values.yaml
+++ b/deployment/monocular/values.yaml
@@ -97,7 +97,9 @@ ingress:
   ## Ingress annotations
   ##
   annotations:
-  #   kubernetes.io/tls-acme: 'true'
+    ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: nginx
+  #  kubernetes.io/tls-acme: 'true'
 
   ## Ingress TLS configuration
   ## Secrets must be manually created in the namespace


### PR DESCRIPTION
This removes the hard dependency on the nginx ingress controller and
enables the use of other ingress controllers

closes #288