### PR TITLE
travis-ci: revert to older VM image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# Use older version of Trusty VM due to issues in the updated one
+group: deprecated-2017Q2
 language: node_js
 node_js:
   - '6.9.5'


### PR DESCRIPTION
Revert to an older VM image where builds were more reliable

fixes #298 