### PR TITLE
fix CORS for deployments

### DIFF
--- a/deployment/monocular/values.yaml
+++ b/deployment/monocular/values.yaml
@@ -36,9 +36,11 @@ api:
       #  source: my-repository-source
     cors:
       allowed_origins:
-        - my-api-server
+        - ""
+        # e.g. UI served on a different domain
+        # - http://monocular.local
       allowed_headers:
-        - "access-control-allow-headers"
+        - "content-type"
         - "x-xsrf-token"
     # Enable Helm deployment integration
     releasesEnabled: true

--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -15,9 +15,9 @@ repos:
 
 # cors:
 #   allowed_origins:
-#     - my-api-server
+#     - my-ui-hostname
 #   allowed_headers:
-#     - "access-control-allow-headers"
+#     - "content-type"
 #     - "x-xsrf-token"
 
 # Enables Helm deployment integration

--- a/src/api/config/cors/cors.go
+++ b/src/api/config/cors/cors.go
@@ -27,8 +27,8 @@ func defaultCors() (Cors, error) {
 	}
 	// Defaults
 	return Cors{
-		AllowedOrigins: []string{"my-api-server"},
-		AllowedHeaders: []string{"access-control-allow-headers", "x-xsrf-token"},
+		AllowedOrigins: []string{""},
+		AllowedHeaders: []string{"content-type", "x-xsrf-token"},
 	}, nil
 }
 

--- a/src/api/config/cors/cors_test.go
+++ b/src/api/config/cors/cors_test.go
@@ -12,8 +12,8 @@ var configFileOk = filepath.Join("..", "testdata", "config.yaml")
 var configFileNotOk = filepath.Join("..", "testdata", "bogus_config.yaml")
 var configFileNoCors = filepath.Join("..", "testdata", "nocors_config.yaml")
 var defaultExpectedCors = Cors{
-	AllowedOrigins: []string{"my-api-server"},
-	AllowedHeaders: []string{"access-control-allow-headers", "x-xsrf-token"},
+	AllowedOrigins: []string{""},
+	AllowedHeaders: []string{"content-type", "x-xsrf-token"},
 }
 
 func TestConfigFileDoesNotExist(t *testing.T) {


### PR DESCRIPTION
This sets the correct allowed headers by default so that deployments can be created when Monocular is deployed with differing hostnames

fixes #291 