### PR TITLE
helm - bump mongodb requirement

### DIFF
--- a/deployment/monocular/Chart.yaml
+++ b/deployment/monocular/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: monocular
 description: Monocular is a search and discovery front end for Helm Charts Repositories.
-version: 0.6.3
+version: 0.6.4
 appVersion: v0.7.3
 home: https://github.com/helm/monocular
 sources:

--- a/deployment/monocular/requirements.lock
+++ b/deployment/monocular/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 0.4.17
-digest: sha256:eb1a1c19c8ce55d297523b3352e7c0bf0ee9006638d249d35e01a989a4b03a77
-generated: 2017-10-08T10:11:39.383800061+01:00
+  version: 4.0.4
+digest: sha256:7e072fdbba9a9d8bc8235bf9959f7f7ed572022c919561377af8a21778a2b458
+generated: 2018-08-01T09:40:57.08419439+02:00

--- a/deployment/monocular/requirements.yaml
+++ b/deployment/monocular/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mongodb
-  version: 0.4.17
+  version: 4.0.4
   repository: https://kubernetes-charts.storage.googleapis.com

--- a/deployment/monocular/templates/api-config.yaml
+++ b/deployment/monocular/templates/api-config.yaml
@@ -11,5 +11,5 @@ data:
   monocular.yaml: |-
     mongodb:
       url: {{ template "mongodb.fullname" . }}:27017
-      database: monocular
+      database: {{ .Values.mongodb.mongodbDatabase }}
 {{ toYaml .Values.api.config | indent 4 -}}

--- a/deployment/monocular/values.yaml
+++ b/deployment/monocular/values.yaml
@@ -131,3 +131,6 @@ ingress:
   ##
   # tls:
   #   secretName: monocular.local-tls
+
+mongodb:
+  mongodbDatabase: monocular


### PR DESCRIPTION
bump mongodb requirement to 4.0.4 and create a default database monocular

fix #419 