### PR TITLE
add jobs and cronjobs for syncing chart repos

### DIFF
--- a/deployment/monocular/templates/_helpers.tpl
+++ b/deployment/monocular/templates/_helpers.tpl
@@ -22,3 +22,56 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "mongodb.fullname" -}}
 {{- printf "%s-%s" .Release.Name "mongodb" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Render image reference
+*/}}
+{{- define "monocular.image" -}}
+{{ .registry }}/{{ .repository }}:{{ .tag }}
+{{- end -}}
+
+{{/*
+Sync job pod template
+*/}}
+{{- define "monocular.sync.podTemplate" -}}
+{{- $repo := index . 0 -}}
+{{- $global := index . 1 -}}
+metadata:
+  labels:
+    monocular.helm.sh/repo-name: {{ $repo.name }}
+    app: {{ template "fullname" $global }}
+    release: "{{ $global.Release.Name }}"
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - name: sync
+    image: {{ template "monocular.image" $global.Values.sync.image }}
+    args:
+    - sync
+    - --mongo-url={{ template "mongodb.fullname" $global }}
+    - --mongo-user=root
+    - {{ $repo.name }}
+    - {{ $repo.url }}
+    command:
+    - /chart-repo
+    env:
+    - name: MONGO_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          key: mongodb-root-password
+          name: {{ template "mongodb.fullname" $global }}
+    resources:
+{{ toYaml $global.Values.sync.resources | indent 6 }}
+{{- with $global.Values.sync.nodeSelector }}
+  nodeSelector:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with $global.Values.sync.affinity }}
+  affinity:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with $global.Values.sync.tolerations }}
+  tolerations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end -}}

--- a/deployment/monocular/templates/repo-sync-cronjobs.yaml
+++ b/deployment/monocular/templates/repo-sync-cronjobs.yaml
@@ -1,0 +1,25 @@
+{{- range .Values.sync.repos }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "fullname" $ }}-sync-scheduled-{{ .name }}
+  labels:
+    monocular.helm.sh/repo-name: {{ .name }}
+    app: {{ template "fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+spec:
+  jobTemplate:
+    metadata:
+      labels:
+        monocular.helm.sh/repo-name: {{ .name }}
+        app: {{ template "fullname" $ }}
+        release: "{{ $.Release.Name }}"
+    spec:
+      template:
+{{ include "monocular.sync.podTemplate" (list . $) | indent 8 }}
+  schedule: "0 * * * *"
+  successfulJobsHistoryLimit: 3
+---
+{{- end -}}

--- a/deployment/monocular/templates/repo-sync-jobs.yaml
+++ b/deployment/monocular/templates/repo-sync-jobs.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "fullname" $ }}-sync-initial-{{ .name }}
+  name: {{ template "fullname" $ }}-sync-initial-{{ .name }}-{{ randAlphaNum 5 | lower }}
   labels:
     monocular.helm.sh/repo-name: {{ .name }}
     app: {{ template "fullname" $ }}

--- a/deployment/monocular/templates/repo-sync-jobs.yaml
+++ b/deployment/monocular/templates/repo-sync-jobs.yaml
@@ -1,0 +1,16 @@
+{{- range .Values.sync.repos }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "fullname" $ }}-sync-initial-{{ .name }}
+  labels:
+    monocular.helm.sh/repo-name: {{ .name }}
+    app: {{ template "fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+spec:
+  template:
+{{ include "monocular.sync.podTemplate" (list . $) | indent 4 }}
+---
+{{- end -}}

--- a/deployment/monocular/values.yaml
+++ b/deployment/monocular/values.yaml
@@ -1,6 +1,31 @@
-# Default values for monocular.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+sync:
+  # Image used to perform chart repository syncs
+  image:
+    registry: docker.io
+    repository: kubeapps/chart-repo
+    tag: latest
+  repos:
+    # Official repositories
+    - name: stable
+      url: https://kubernetes-charts.storage.googleapis.com
+    - name: incubator
+      url: https://kubernetes-charts-incubator.storage.googleapis.com
+    # Add your own repository
+    #- name: my-repo-name
+    #  url: my-repository-url
+    #  source: my-repository-source
+  resources: {}
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# OLD API CONFIG
 api:
   replicaCount: 2
   image:
@@ -133,4 +158,5 @@ ingress:
   #   secretName: monocular.local-tls
 
 mongodb:
-  mongodbDatabase: monocular
+  persistence:
+    enabled: false

--- a/deployment/monocular/values.yaml
+++ b/deployment/monocular/values.yaml
@@ -3,7 +3,7 @@ sync:
   image:
     registry: docker.io
     repository: kubeapps/chart-repo
-    tag: latest
+    tag: v1.0.0-beta.0
   repos:
     # Official repositories
     - name: stable


### PR DESCRIPTION
As part of moving the chart repository syncing outside of the main
Monocular API process, we will use a CronJob to sync chart repositories
on a schedule. The list of repositories to sync will be defined by the
value in this chart. A Job is used for the initial sync at install time.

fixes #507 