### PR TITLE
adds chartsvc deployment to the chart

### DIFF
--- a/deployment/monocular/templates/chartsvc-deployment.yaml
+++ b/deployment/monocular/templates/chartsvc-deployment.yaml
@@ -36,6 +36,10 @@ spec:
         ports:
         - name: http
           containerPort: {{ .Values.chartsvc.service.port }}
+        livenessProbe:
+{{ toYaml .Values.chartsvc.livenessProbe | indent 10 }}
+        readinessProbe:
+{{ toYaml .Values.chartsvc.readinessProbe | indent 10 }}
         resources:
 {{ toYaml .Values.chartsvc.resources | indent 12 }}
     {{- with .Values.chartsvc.nodeSelector }}

--- a/deployment/monocular/templates/chartsvc-deployment.yaml
+++ b/deployment/monocular/templates/chartsvc-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  replicas: 1
+  replicas: {{ .Values.chartsvc.replicas }}
   selector:
     matchLabels:
       app: {{ template "fullname" . }}-chartsvc

--- a/deployment/monocular/templates/chartsvc-deployment.yaml
+++ b/deployment/monocular/templates/chartsvc-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}-chartsvc
+  labels:
+    app: {{ template "fullname" . }}-chartsvc
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}-chartsvc
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}-chartsvc
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: chartsvc
+        image: {{ template "monocular.image" .Values.chartsvc.image }}
+        command:
+        - /chartsvc
+        args:
+        - --mongo-user=root
+        - --mongo-url={{ template "mongodb.fullname" . }}
+        env:
+        - name: MONGO_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mongodb.fullname" . }}
+              key: mongodb-root-password
+        ports:
+        - name: http
+          containerPort: {{ .Values.chartsvc.service.port }}
+        resources:
+{{ toYaml .Values.chartsvc.resources | indent 12 }}
+    {{- with .Values.chartsvc.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.chartsvc.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.chartsvc.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/deployment/monocular/templates/chartsvc-service.yaml
+++ b/deployment/monocular/templates/chartsvc-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}-chartsvc
+  labels:
+    app: {{ template "fullname" . }}-chartsvc
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: ClusterIP
+  ports:
+  - port: {{ .Values.chartsvc.service.port }}
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: {{ template "fullname" . }}-chartsvc
+    release: {{ .Release.Name }}

--- a/deployment/monocular/values.yaml
+++ b/deployment/monocular/values.yaml
@@ -20,6 +20,25 @@ sync:
     #  memory: 128Mi
     # requests:
     #  cpu: 100m
+   #  memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Chartsvc is used to serve chart metadata over a REST API.
+chartsvc:
+  image:
+    registry: docker.io
+    repository: kubeapps/chartsvc
+    tag: v1.0.0-beta.0
+  service:
+    port: 8080
+  resources: {}
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
     #  memory: 128Mi
   nodeSelector: {}
   tolerations: []

--- a/deployment/monocular/values.yaml
+++ b/deployment/monocular/values.yaml
@@ -33,6 +33,7 @@ chartsvc:
     tag: v1.0.0-beta.0
   service:
     port: 8080
+  # TODO: review suggested resource limits/requests
   resources: {}
     # limits:
     #  cpu: 100m

--- a/deployment/monocular/values.yaml
+++ b/deployment/monocular/values.yaml
@@ -43,6 +43,18 @@ chartsvc:
     # requests:
     #  cpu: 100m
     #  memory: 128Mi
+  livenessProbe:
+    httpGet:
+      path: /live
+      port: 8080
+    initialDelaySeconds: 60
+    timeoutSeconds: 5
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: 8080
+    initialDelaySeconds: 0
+    timeoutSeconds: 5
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/deployment/monocular/values.yaml
+++ b/deployment/monocular/values.yaml
@@ -33,6 +33,7 @@ chartsvc:
     tag: v1.0.0-beta.0
   service:
     port: 8080
+  replicas: 3
   # TODO: review suggested resource limits/requests
   resources: {}
     # limits:

--- a/deployment/monocular/values.yaml
+++ b/deployment/monocular/values.yaml
@@ -14,6 +14,7 @@ sync:
     #- name: my-repo-name
     #  url: my-repository-url
     #  source: my-repository-source
+  # TODO: review suggested resource limits/requests
   resources: {}
     # limits:
     #  cpu: 100m


### PR DESCRIPTION
chartsvc is intended to replace the existing Monocular API server for serving the chart metadata being synced using the chart-repo tool over a REST API. It implements the same routes as the Monocular API server for charts and chart versions: https://github.com/helm/monocular/blob/master/src/api/main.go#L81-L91

fixes #500