### PR TITLE
Updates the Monocular UI to use the chartsvc API

### DIFF
--- a/deployment/monocular/templates/ingress.yaml
+++ b/deployment/monocular/templates/ingress.yaml
@@ -25,6 +25,10 @@ spec:
           serviceName: {{ template "fullname" $ }}-api
           servicePort: {{ $.Values.api.service.externalPort }}
         path: /api/
+      - backend:
+          serviceName: {{ template "fullname" $ }}-chartsvc
+          servicePort: {{ $.Values.chartsvc.service.port }}
+        path: /api/chartsvc
     host: {{ . | quote }}
   {{- end }}
 {{- if .Values.ingress.tls }}

--- a/src/ui/src/app/chart-details/chart-details-info/chart-details-info.component.html
+++ b/src/ui/src/app/chart-details/chart-details-info/chart-details-info.component.html
@@ -12,12 +12,6 @@
         <a href="{{ chart.attributes.home }}" target="_blank">{{chart.attributes.home}}</a>
       </div>
     </div>
-    <div class="chartInfo__source" *ngIf="sourceUrl">
-      <h1>Source repository</h1>
-      <div>
-        <a href="{{ sourceUrl }}" target="_blank">{{ sourceName }}</a>
-      </div>
-    </div>
     <div class="chartInfo__maintainers">
       <h1>Maintainers</h1>
       <div *ngFor="let maintainer of maintainers">

--- a/src/ui/src/app/chart-details/chart-details-info/chart-details-info.component.ts
+++ b/src/ui/src/app/chart-details/chart-details-info/chart-details-info.component.ts
@@ -24,21 +24,8 @@ export class ChartDetailsInfoComponent implements OnInit {
     return this.chart.attributes.sources || [];
   }
 
-  get sourceUrl(): string {
-    var chartSource = this.chart.attributes.repo.source;
-    if (!chartSource) return;
-
-    return urljoin(chartSource, this.chart.attributes.name);
-  }
-
   get maintainers(): Maintainer[] {
     return this.chart.attributes.maintainers || [];
-  }
-
-  get sourceName(): string {
-    var parser = document.createElement('a');
-    parser.href = this.chart.attributes.repo.source;
-    return parser.hostname;
   }
 
   loadVersions(chart: Chart): void {

--- a/src/ui/src/app/chart-details/chart-details-info/chart-details-info.component.ts
+++ b/src/ui/src/app/chart-details/chart-details-info/chart-details-info.component.ts
@@ -50,14 +50,16 @@ export class ChartDetailsInfoComponent implements OnInit {
   }
 
   maintainerUrl(maintainer: Maintainer): string {
-    if (this.isKubernetesCharts(this.chart.attributes.repo.URL)) {
+    // Use GitHub URL with maintainer name if this is an upstream Helm repo from
+    // github.com/helm/charts (i.e. stable or incubator)
+    if (this.isUpstreamHelmRepo(this.chart.attributes.repo.url)) {
       return `https://github.com/${maintainer.name}`;
     } else {
       return `mailto:${maintainer.email}`;
     }
   }
 
-  private isKubernetesCharts(repoURL: string): boolean {
+  private isUpstreamHelmRepo(repoURL: string): boolean {
     return (
       repoURL === "https://kubernetes-charts.storage.googleapis.com" ||
       repoURL === "https://kubernetes-charts-incubator.storage.googleapis.com"

--- a/src/ui/src/app/chart-details/chart-details-info/chart-details-info.component.ts
+++ b/src/ui/src/app/chart-details/chart-details-info/chart-details-info.component.ts
@@ -50,10 +50,17 @@ export class ChartDetailsInfoComponent implements OnInit {
   }
 
   maintainerUrl(maintainer: Maintainer): string {
-    if (this.chart.attributes.repo.source.match(/github.com/)) {
+    if (this.isKubernetesCharts(this.chart.attributes.repo.URL)) {
       return `https://github.com/${maintainer.name}`;
     } else {
       return `mailto:${maintainer.email}`;
     }
+  }
+
+  private isKubernetesCharts(repoURL: string): boolean {
+    return (
+      repoURL === "https://kubernetes-charts.storage.googleapis.com" ||
+      repoURL === "https://kubernetes-charts-incubator.storage.googleapis.com"
+    );
   }
 }

--- a/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
+++ b/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
@@ -10,7 +10,7 @@
       <p *ngIf="installing"><mat-progress-bar mode="indeterminate"></mat-progress-bar></p>
     </mat-tab>
     <mat-tab label="Helm CLI">
-      <div *ngIf=!showRepoInstructions class="chart-details-usage__repository">
+      <div *ngIf="showRepoInstructions" class="chart-details-usage__repository">
         <h2 class="chart-details-usage__label">Add {{ chart.attributes.repo.name }} repository</h2>
         <mat-form-field>
           <input matInput floatingPlaceholder=false [value]=repoAddInstructions>

--- a/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.ts
+++ b/src/ui/src/app/chart-details/chart-details-usage/chart-details-usage.component.ts
@@ -58,7 +58,7 @@ export class ChartDetailsUsageComponent implements OnInit {
 
   get repoAddInstructions(): string {
     return `helm repo add ${this.chart.attributes.repo.name} ${this.chart
-      .attributes.repo.URL}`;
+      .attributes.repo.url}`;
   }
 
   get installInstructions(): string {

--- a/src/ui/src/app/chart-details/chart-details.component.ts
+++ b/src/ui/src/app/chart-details/chart-details.component.ts
@@ -71,12 +71,8 @@ export class ChartDetailsComponent implements OnInit {
   }
 
   getIconUrl(): string {
-    let icons = this.chart.relationships.latestChartVersion.data.icons;
-    if (icons !== undefined && icons.length > 0) {
-      const icon =
-        this.config.backendHostname +
-        icons.find(icon => icon.name === '160x160-fit').path;
-      return icon;
+    if (this.chart.attributes.icon) {
+      return this.chartsService.getChartIconURL(this.chart);
     } else {
       return '/assets/images/placeholder.png';
     }

--- a/src/ui/src/app/chart-details/chart-details.component.ts
+++ b/src/ui/src/app/chart-details/chart-details.component.ts
@@ -43,7 +43,7 @@ export class ChartDetailsComponent implements OnInit {
             this.titleVersion = this.currentVersion.attributes.app_version || '';
             this.updateMetaTags();
           });
-        this.iconUrl = this.getIconUrl();
+        this.iconUrl = this.chartsService.getChartIconURL(this.chart);
       });
     });
   }
@@ -68,13 +68,5 @@ export class ChartDetailsComponent implements OnInit {
 
   goToRepoUrl(): string {
     return `/charts/${this.chart.attributes.repo.name}`;
-  }
-
-  getIconUrl(): string {
-    if (this.chart.attributes.icon) {
-      return this.chartsService.getChartIconURL(this.chart);
-    } else {
-      return '/assets/images/placeholder.png';
-    }
   }
 }

--- a/src/ui/src/app/chart-item/chart-item.component.ts
+++ b/src/ui/src/app/chart-item/chart-item.component.ts
@@ -20,7 +20,7 @@ export class ChartItemComponent implements OnInit {
   constructor(private chartsService: ChartsService) {}
 
   ngOnInit() {
-    this.iconUrl = this.getIconUrl();
+    this.iconUrl = this.chartsService.getChartIconURL(this.chart);
   }
 
   goToDetailUrl(): string {
@@ -30,13 +30,5 @@ export class ChartItemComponent implements OnInit {
 
   goToRepoUrl(): string {
     return `/charts/${this.chart.attributes.repo.name}`;
-  }
-
-  getIconUrl(): string {
-    if (this.chart.attributes.icon) {
-      return this.chartsService.getChartIconURL(this.chart);
-    } else {
-      return '/assets/images/placeholder.png';
-    }
   }
 }

--- a/src/ui/src/app/chart-item/chart-item.component.ts
+++ b/src/ui/src/app/chart-item/chart-item.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Chart } from '../shared/models/chart';
-import { ConfigService } from '../shared/services/config.service';
+import { ChartsService } from '../shared/services/charts.service';
 
 @Component({
   selector: 'app-chart-item',
@@ -17,7 +17,7 @@ export class ChartItemComponent implements OnInit {
   // Truncate the description
   public showDescription: boolean = true;
 
-  constructor(private config: ConfigService) {}
+  constructor(private chartsService: ChartsService) {}
 
   ngOnInit() {
     this.iconUrl = this.getIconUrl();
@@ -33,12 +33,8 @@ export class ChartItemComponent implements OnInit {
   }
 
   getIconUrl(): string {
-    let icons = this.chart.relationships.latestChartVersion.data.icons;
-    if (icons !== undefined && icons.length > 0) {
-      const icon =
-        this.config.backendHostname +
-        icons.find(icon => icon.name === '160x160-fit').path;
-      return icon;
+    if (this.chart.attributes.icon) {
+      return this.chartsService.getChartIconURL(this.chart);
     } else {
       return '/assets/images/placeholder.png';
     }

--- a/src/ui/src/app/shared/models/repo.ts
+++ b/src/ui/src/app/shared/models/repo.ts
@@ -6,6 +6,5 @@ export class Repo {
 
 export class RepoAttributes {
   name: string = '';
-  URL: string = '';
-  source: string = '';
+  url: string = '';
 }

--- a/src/ui/src/app/shared/services/charts.service.ts
+++ b/src/ui/src/app/shared/services/charts.service.ts
@@ -130,7 +130,7 @@ export class ChartsService {
   /**
    * Get the URL for retrieving the chart's icon
    * 
-   * @param {string} chart Chart object
+   * @param {Chart} chart Chart object
    */
   getChartIconURL(chart: Chart): string {
     if (chart.attributes.icon) {

--- a/src/ui/src/app/shared/services/charts.service.ts
+++ b/src/ui/src/app/shared/services/charts.service.ts
@@ -20,7 +20,7 @@ export class ChartsService {
     private http: Http,
     private config: ConfigService
   ) {
-    this.hostname = config.backendHostname;
+    this.hostname = `${config.backendHostname}/chartsvc`;
     this.cacheCharts = {};
   }
 
@@ -125,6 +125,19 @@ export class ChartsService {
     return this.http.get(`${this.hostname}/v1/charts/${repo}/${chartName}/versions/${version}`)
       .map(this.extractData)
       .catch(this.handleError);
+  }
+
+  /**
+   * Get the URL for retrieving the chart's icon
+   * 
+   * @param {string} chart Chart object
+   */
+  getChartIconURL(chart: Chart): string {
+    if (chart.attributes.icon) {
+      return `${this.hostname}${chart.attributes.icon}`
+    } else {
+      return null;
+    }
   }
 
   /**

--- a/src/ui/src/app/shared/services/charts.service.ts
+++ b/src/ui/src/app/shared/services/charts.service.ts
@@ -136,7 +136,7 @@ export class ChartsService {
     if (chart.attributes.icon) {
       return `${this.hostname}${chart.attributes.icon}`
     } else {
-      return null;
+      return '/assets/images/placeholder.png';
     }
   }
 


### PR DESCRIPTION
In https://github.com/helm/monocular/pull/509 we added the chartsvc
service to the Monocular distribution, intended to be a lighter-weight,
read-only replacement for the Monocular API server. This PR updates the
Monocular UI to switch to the new chartsvc API for all chart-related API
calls.

fixes #501