### PR TITLE
change charts list component to extract repos from list of charts

### DIFF
--- a/frontend/src/app/charts/charts.component.ts
+++ b/frontend/src/app/charts/charts.component.ts
@@ -92,6 +92,9 @@ export class ChartsComponent implements OnInit {
     });
   }
   
+  // This takes a list of charts, extracts the unique set of repositories the
+  // charts are from and sets the Repositories filter with that list. We also
+  // add an 'all' repository filter at the top.
   setReposFromCharts(charts: Chart[]): void {
     let repoMap = new Map<string, RepoAttributes>();
     repoMap['all'] = { name: 'All' };


### PR DESCRIPTION
The old Monocular API supported a repos endpoint that returned a list of
configured repos, but this endpoint is not supported by the chartsvc.
Instead of reimplementing it, we can extract the list of repos from the
charts list response client-side. This updates the chart list component
to always fetch all charts (regardless of a selected repo) allowing it
to extract the full list of repos to show. The full charts list is then
filtered by the selected repo to preserve the same functionality as the
/api/chartsvc/v1/charts/{repoName} endpoint previously used.

Signed-off-by: Adnan Abdulhussein <adnan@bitnami.com>