### PR TITLE
update travis config to push images to quay.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ cache:
 services:
   - docker
 # UI dependencies
+env:
+  - IMAGE_PREFIX=quay.io/helmpack
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
@@ -23,10 +25,10 @@ after_success:
   - |
     if [[ "$TRAVIS_PULL_REQUEST" = false ]] && [[ "$TRAVIS_BRANCH" = "master" || -n "$TRAVIS_TAG" ]]; then
       if [[ -n "$TRAVIS_TAG" ]]; then
-        docker tag bitnami/monocular-ui:latest bitnami/monocular-ui:$TRAVIS_TAG
+        docker tag $IMAGE_PREFIX/monocular-ui:latest $IMAGE_PREFIX/monocular-ui:$TRAVIS_TAG
       fi
       docker login -u="$DOCKER_USER" -p="$DOCKER_PASSWORD"
-      docker push bitnami/monocular-ui
+      docker push $IMAGE_PREFIX/monocular-ui
 
       ./scripts/repo-sync.sh
     fi

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,4 +1,4 @@
-IMAGE_REPO ?= bitnami/monocular-ui
+IMAGE_REPO ?= quay.io/helmpack/monocular-ui
 IMAGE_TAG ?= latest
 
 ifeq "$(VERSION)" ""


### PR DESCRIPTION
Travis config in the UI has been updated to have DOCKER_USER and
DOCKER_PASSWORD point to a robot account in Quay.

Signed-off-by: Adnan Abdulhussein <adnan@bitnami.com>