### PR TITLE
fix image references and release script to tag correctly

### DIFF
--- a/chart/monocular/Chart.yaml
+++ b/chart/monocular/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: monocular
 description: Monocular is a search and discovery front end for Helm Charts Repositories.
-version: 0.6.5
+version: 1.0.0
 appVersion: v1.0.0
 home: https://github.com/helm/monocular
 sources:

--- a/chart/monocular/values.yaml
+++ b/chart/monocular/values.yaml
@@ -2,8 +2,8 @@ sync:
   # Image used to perform chart repository syncs
   image:
     registry: docker.io
-    repository: kubeapps/chart-repo
-    tag: v1.0.0-beta.0
+    repository: quay.io/helmpack/chart-repo
+    tag: v1.0.0
   repos:
     # Official repositories
     - name: stable
@@ -30,8 +30,8 @@ sync:
 chartsvc:
   image:
     registry: docker.io
-    repository: kubeapps/chartsvc
-    tag: v1.0.0-beta.0
+    repository: quay.io/helmpack/chartsvc
+    tag: v1.0.0
   service:
     port: 8080
   replicas: 3
@@ -63,7 +63,7 @@ ui:
   replicaCount: 2
   image:
     repository: quay.io/helmpack/monocular-ui
-    tag: v0.7.3
+    tag: v1.0.0
     pullPolicy: Always
   service:
     name: monocular-ui

--- a/scripts/repo-sync.sh
+++ b/scripts/repo-sync.sh
@@ -73,7 +73,7 @@ update_chart_version() {
   CHART_VERSION_NEXT="${CHART_VERSION%.*}.$((${CHART_VERSION##*.}+1))"
   sed -i 's|^version:.*|version: '"$CHART_VERSION_NEXT"'|g' $CHART_PATH/Chart.yaml
   sed -i 's|^appVersion:.*|appVersion: '"$IMAGE_TAG"'|g' $CHART_PATH/Chart.yaml
-  sed -i '/bitnami\/monocular/{n; s/tag:.*/tag: '"$IMAGE_TAG"'/}' $CHART_PATH/values.yaml
+  sed -i '/quay.io\/helmpack/{n; s/tag:.*/tag: '"$IMAGE_TAG"'/}' $CHART_PATH/values.yaml
 
   if [ $COMMIT_CHANGES != "false" ]; then
     log "Commiting chart source changes to master branch"


### PR DESCRIPTION
The chart pushed with the 1.0 release had incorrect image references,
this PR updates the chart to point to the correct quay.io/helmpack repos
and also fixes the repo-sync script to automatically update this in the
future.

I've also bumped the chart version to 1.0 to indicate the major changes.

fixes #541