### PR TITLE
External MongoDB chart option

### DIFF
--- a/chart/monocular/README.md
+++ b/chart/monocular/README.md
@@ -107,3 +107,4 @@ $ helm install monocular/monocular -f custom-domains.yaml
 | `ingress.enabled`       | If enabled, create an Ingress object     | `true`                                                                          |
 | `ingress.annotations`   | Ingress annotations                      | `{ingress.kubernetes.io/rewrite-target: /, kubernetes.io/ingress.class: nginx}` |
 | `ingress.tls`           | TLS configuration for the Ingress object | `nil`                                                                           |
+| `global.mongoUrl`       | External MongoDB connection URL          | `nil`                                                                           |

--- a/chart/monocular/requirements.lock
+++ b/chart/monocular/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 4.6.2
-digest: sha256:173d5b596de1bdcd48a1de7d60c9ab5f58265242156604b89a12b01b91bf17be
-generated: 2018-10-25T16:00:10.873889+02:00
+digest: sha256:ccc841efc96895bd5982021aa2fd5300b99acdcddc1bc144f020572f27990c34
+generated: 2018-10-25T22:57:16.837922292-04:00

--- a/chart/monocular/requirements.yaml
+++ b/chart/monocular/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
 - name: mongodb
   version: 4.6.2
   repository: https://kubernetes-charts.storage.googleapis.com
+  condition: mongodb.enabled

--- a/chart/monocular/templates/_helpers.tpl
+++ b/chart/monocular/templates/_helpers.tpl
@@ -48,18 +48,24 @@ spec:
     image: {{ template "monocular.image" $global.Values.sync.image }}
     args:
     - sync
+    {{- if and .Values.global.mongoUrl (not .Values.mongodb.enabled) -}}
+    - --mongo-url={{ .Values.global.mongoUrl }}
+    {{- else }}
     - --mongo-url={{ template "mongodb.fullname" $global }}
     - --mongo-user=root
+    {{- end }}
     - {{ $repo.name }}
     - {{ $repo.url }}
     command:
     - /chart-repo
+    {{- if .Values.mongodb.enabled }}
     env:
     - name: MONGO_PASSWORD
       valueFrom:
         secretKeyRef:
           key: mongodb-root-password
           name: {{ template "mongodb.fullname" $global }}
+    {{- end }}
     resources:
 {{ toYaml $global.Values.sync.resources | indent 6 }}
 {{- with $global.Values.sync.nodeSelector }}

--- a/chart/monocular/templates/_helpers.tpl
+++ b/chart/monocular/templates/_helpers.tpl
@@ -48,7 +48,7 @@ spec:
     image: {{ template "monocular.image" $global.Values.sync.image }}
     args:
     - sync
-    {{- if and $global.Values.global.mongoUrl (not $global.Values.mongodb.enabled) -}}
+    {{- if and $global.Values.global.mongoUrl (not $global.Values.mongodb.enabled) }}
     - --mongo-url={{ .Values.global.mongoUrl }}
     {{- else }}
     - --mongo-url={{ template "mongodb.fullname" $global }}

--- a/chart/monocular/templates/_helpers.tpl
+++ b/chart/monocular/templates/_helpers.tpl
@@ -49,7 +49,7 @@ spec:
     args:
     - sync
     {{- if and $global.Values.global.mongoUrl (not $global.Values.mongodb.enabled) }}
-    - --mongo-url={{ .Values.global.mongoUrl }}
+    - --mongo-url={{ $global.Values.global.mongoUrl }}
     {{- else }}
     - --mongo-url={{ template "mongodb.fullname" $global }}
     - --mongo-user=root

--- a/chart/monocular/templates/_helpers.tpl
+++ b/chart/monocular/templates/_helpers.tpl
@@ -48,7 +48,7 @@ spec:
     image: {{ template "monocular.image" $global.Values.sync.image }}
     args:
     - sync
-    {{- if and .Values.global.mongoUrl (not .Values.mongodb.enabled) -}}
+    {{- if and $global.Values.global.mongoUrl (not $global.Values.mongodb.enabled) -}}
     - --mongo-url={{ .Values.global.mongoUrl }}
     {{- else }}
     - --mongo-url={{ template "mongodb.fullname" $global }}
@@ -58,7 +58,7 @@ spec:
     - {{ $repo.url }}
     command:
     - /chart-repo
-    {{- if .Values.mongodb.enabled }}
+    {{- if $global.Values.mongodb.enabled }}
     env:
     - name: MONGO_PASSWORD
       valueFrom:

--- a/chart/monocular/templates/chartsvc-deployment.yaml
+++ b/chart/monocular/templates/chartsvc-deployment.yaml
@@ -25,6 +25,9 @@ spec:
         command:
         - /chartsvc
         args:
+        {{- if and .Values.global.mongoUrl (not .Values.mongodb.enabled) -}}
+        - --mongo-url={{ .Values.global.mongoUrl }}
+        {{- else }}
         - --mongo-user=root
         - --mongo-url={{ template "mongodb.fullname" . }}
         env:
@@ -33,6 +36,7 @@ spec:
             secretKeyRef:
               name: {{ template "mongodb.fullname" . }}
               key: mongodb-root-password
+        {{- end }}
         ports:
         - name: http
           containerPort: {{ .Values.chartsvc.service.port }}

--- a/chart/monocular/templates/chartsvc-deployment.yaml
+++ b/chart/monocular/templates/chartsvc-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         command:
         - /chartsvc
         args:
-        {{- if and .Values.global.mongoUrl (not .Values.mongodb.enabled) -}}
+        {{- if and .Values.global.mongoUrl (not .Values.mongodb.enabled) }}
         - --mongo-url={{ .Values.global.mongoUrl }}
         {{- else }}
         - --mongo-user=root

--- a/chart/monocular/values.yaml
+++ b/chart/monocular/values.yaml
@@ -137,5 +137,13 @@ ingress:
   #   secretName: monocular.local-tls
 
 mongodb:
+  enabled: true
   persistence:
     enabled: false
+
+# External MongoDB connection URL.
+# This must be set if mongodb.enabled is set to false, following the pattern:
+# `mongodb://${MONGODB_USER}:${MONGODB_PASSWORD}@custom-mongodb.local:27017/${MONGODB_DATABSE}`
+# ref: https://docs.mongodb.com/manual/reference/connection-string/
+global:
+  mongoUrl:

--- a/chart/monocular/values.yaml
+++ b/chart/monocular/values.yaml
@@ -143,7 +143,7 @@ mongodb:
 
 # External MongoDB connection URL.
 # This must be set if mongodb.enabled is set to false, following the pattern:
-# `mongodb://${MONGODB_USER}:${MONGODB_PASSWORD}@custom-mongodb.local:27017/${MONGODB_DATABSE}`
+# `mongodb://${MONGODB_USER}:${MONGODB_ROOT_PASSWORD}@${MONGODB_DNS}:${MONGODB_PORT}/${MONGODB_DATABASE}`
 # ref: https://docs.mongodb.com/manual/reference/connection-string/
 global:
   mongoUrl:


### PR DESCRIPTION
@prydonius Here's a first pass at the external MongoDB chart option.

Not yet tested - but had some spare time tonight, so opening this for feedback.

The things I'm least sure about are chartsvc and chart-repo sync. I took a look at the [dbURL note](https://github.com/helm/monocular/blob/master/cmd/chartsvc/main.go#L60) about [mgo DIAL](https://godoc.org/labix.org/v2/mgo#Dial), and looked at [datastore.Config](https://github.com/kubeapps/common/blob/master/datastore/datastore.go#L28) briefly... it seems a fully formed `mongo-url` may work in place of the other commands (`mongo-user` with simple `mongo-url`) and `MONGO_PASSWORD` ENV var?

Once this PR is resolved, it should fix #404