### PR TITLE
add dev documentation for chart-repo and chartsvc

### DIFF
--- a/cmd/chart-repo/Dockerfile
+++ b/cmd/chart-repo/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/deis/go-dev:v1.8.2 as builder
+FROM golang:1.11 as builder
 COPY . /go/src/github.com/helm/monocular
 WORKDIR /go/src/github.com/helm/monocular
 RUN CGO_ENABLED=0 go build -a -installsuffix cgo ./cmd/chart-repo

--- a/cmd/chartsvc/Dockerfile
+++ b/cmd/chartsvc/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/deis/go-dev:v1.8.2 as builder
+FROM golang:1.11 as builder
 COPY . /go/src/github.com/helm/monocular
 WORKDIR /go/src/github.com/helm/monocular
 RUN CGO_ENABLED=0 go build -a -installsuffix cgo ./cmd/chartsvc

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,7 +7,20 @@ This guide explains how to set up your environment for developing on Helm and Ti
 * A Kubernetes cluster with Helm/Tiller installed
 * Telepresence 0.75 or later
 * kubectl 1.2 or later (optional)
+* Go 1.11 or later
+* Go dep https://golang.github.io/dep/
 * Git
+
+## Architecture
+
+The UI is an Angular 2 application located in `frontend/`. This path is mounted
+into the UI container. The server watches for file changes and automatically
+rebuilds the application.
+
+* [UI documentation](../frontend/README.md)
+
+The backend is a small Go REST API service, `chartsvc`, and background CronJobs
+to run the `chart-repo` sync command.
 
 ## Running Monocular
 
@@ -19,7 +32,7 @@ single-node cluster for developing Monocular:
 $ minikube start
 $ minikube addons enable ingress
 $ helm init --wait
-$ helm install --name monocular ./chart/monocular
+$ helm install --name dev --namespace monocular ./chart/monocular
 ```
 
 After a few minutes, you will be able to visit the Monocular in your browser
@@ -32,7 +45,7 @@ server:
 
 ```
 $ docker build -t monocular_ui ./dev_env/ui
-$ telepresence --swap-deployment m-monocular-ui --namespace monocular --expose 4200:8080 --docker-run --rm -ti -v $(pwd)/frontend:/app monocular_ui bash
+$ telepresence --swap-deployment dev-monocular-ui --namespace monocular --expose 4200:8080 --docker-run --rm -ti -v $(pwd)/frontend:/app monocular_ui bash
 ```
 
 Inside the container's bash shell, run the following command to start the
@@ -45,15 +58,40 @@ $ ng serve --host 0.0.0.0 --public-host https://localhost
 Once running, refresh the Ingress address in your browser and you will be
 connected to the development server.
 
-**TODO:** document development instructions for chartsvc and chart-repo.
+## Developing chartsvc
 
-## Architecture
+chartsvc is a Go REST API service. To build it, run the following commands:
 
-The UI is an Angular 2 application located in `frontend/`. This path is mounted
-into the UI container. The server watches for file changes and automatically
-rebuilds the application.
+```
+$ dep ensure
+$ make -C cmd/chartsvc docker-build
+```
 
-* [UI documentation](../frontend/README.md)
+Use Telepresence to run the an instance of the chartsvc locally:
 
-The backend is a small Go REST API service, `chartsvc`, and background CronJobs
-to run the `chart-repo` sync command.
+```
+$ telepresence --swap-deployment dev-monocular-chartsvc --namespace monocular --expose 8080:8080 --docker-run --rm -ti quay.io/helmpack/chartsvc /chartsvc --mongo-user=root --mongo-url=dev-mongodb
+```
+
+Note that the chartsvc should be rebuilt for new changes to take effect.
+
+## Developing chart-repo
+
+chart-repo is a CLI tool that is used within CronJobs to sync against Helm chart
+repositories. In development, it can be run standalone outside of the scheduled
+CronJobs. To build it, run the following commands:
+
+```
+$ dep ensure
+$ make -C cmd/chart-repo docker-build
+```
+
+Use Telepresence to run the image, passing in the repository name and URL as
+arguments:
+
+```
+$ export MONGO_PASSWORD=$(kubectl get secret --namespace monocular dev-mongodb -o jsonpath="{.data.mongodb-root-password}" | base64 --decode)
+$ telepresence --namespace monocular --docker-run -e MONGO_PASSWORD=$MONGO_PASSWORD --rm -ti quay.io/helmpack/chart-repo /chart-repo sync --mongo-user=root --mongo-url=dev-mongodb stable https://kubernetes-charts.storage.googleapis.com
+```
+
+Note that the chart-repo should be rebuilt for new changes to take effect.


### PR DESCRIPTION
Describes how to build and run these tools in the development environment.

Also upgrades Go version to 1.11