### PR TITLE
add http proxy variables for jobs

### DIFF
--- a/chart/monocular/Chart.yaml
+++ b/chart/monocular/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: monocular
 description: Monocular is a search and discovery front end for Helm Charts Repositories.
-version: 1.1.0
+version: 1.2.0
 appVersion: v1.0.0
 home: https://github.com/helm/monocular
 sources:

--- a/chart/monocular/templates/_helpers.tpl
+++ b/chart/monocular/templates/_helpers.tpl
@@ -55,6 +55,10 @@ spec:
     command:
     - /chart-repo
     env:
+    - name: HTTP_PROXY
+      value: {{ $global.Values.sync.httpProxy }}
+    - name: HTTPS_PROXY
+      value: {{ $global.Values.sync.httpsProxy }}
     - name: MONGO_PASSWORD
       valueFrom:
         secretKeyRef:

--- a/chart/monocular/values.yaml
+++ b/chart/monocular/values.yaml
@@ -14,6 +14,9 @@ sync:
     #- name: my-repo-name
     #  url: my-repository-url
     #  source: my-repository-source
+  # Uncomment these properties to set HTTP proxy for chart synchronization jobs
+  # httpProxy:
+  # httpsProxy:
   # TODO: review suggested resource limits/requests
   resources: {}
     # limits:
@@ -21,7 +24,7 @@ sync:
     #  memory: 128Mi
     # requests:
     #  cpu: 100m
-   #  memory: 128Mi
+    #  memory: 128Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
This is my proposal to fix https://github.com/helm/monocular/issues/542

Proxy now can be set in values.yaml, and will be passed as standard HTTP_PROXY and HTTPS_PROXY environment variables to chart-repo/sync which supports it as it is using standard GoLang http library