### PR TITLE
Improve user agent and version handling in chart-repo command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,13 @@ jobs:
       - run: |
           CMDS=(chart-repo chartsvc)
           for CMD in ${CMDS[@]}; do
-            make -C cmd/${CMD} docker-build
+            # If we are in a release we pass the version to the build process to bake the version
+            # By default, if no passed it will use the commit sha
+            if [[ -n "${CIRCLE_TAG}" ]]; then
+              makeArgs="VERSION=${CIRCLE_TAG}"
+            fi
+
+            make -C cmd/${CMD} $makeArgs docker-build
           done
 
           if [[ -z "${CIRCLE_PULL_REQUEST}" && -n "${DOCKER_USERNAME}" && -n "${DOCKER_PASSWORD}" ]] && [[ "${CIRCLE_BRANCH}" == "master" || -n "${CIRCLE_TAG}" ]]; then

--- a/cmd/chart-repo/Dockerfile
+++ b/cmd/chart-repo/Dockerfile
@@ -2,8 +2,8 @@ FROM golang:1.11 as builder
 COPY . /go/src/github.com/helm/monocular
 WORKDIR /go/src/github.com/helm/monocular
 
-ARG CODE_VERSION
-RUN CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "-X main.version=$CODE_VERSION" ./cmd/chart-repo
+ARG VERSION
+RUN CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "-X main.version=$VERSION" ./cmd/chart-repo
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/cmd/chart-repo/Dockerfile
+++ b/cmd/chart-repo/Dockerfile
@@ -1,7 +1,9 @@
 FROM golang:1.11 as builder
 COPY . /go/src/github.com/helm/monocular
 WORKDIR /go/src/github.com/helm/monocular
-RUN CGO_ENABLED=0 go build -a -installsuffix cgo ./cmd/chart-repo
+
+ARG CODE_VERSION
+RUN CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "-X main.version=$CODE_VERSION" ./cmd/chart-repo
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/cmd/chart-repo/Makefile
+++ b/cmd/chart-repo/Makefile
@@ -1,6 +1,8 @@
 IMAGE_REPO ?= quay.io/helmpack/chart-repo
 IMAGE_TAG ?= latest
+# Version of the binary to be produced
+VERSION ?= $$(git rev-parse HEAD)
 
 docker-build:
 	# We use the context of the root dir
-	docker build --pull --rm -t ${IMAGE_REPO}:${IMAGE_TAG} -f Dockerfile ../../
+	docker build --pull --rm -t ${IMAGE_REPO}:${IMAGE_TAG} --build-arg "CODE_VERSION=${VERSION}" -f Dockerfile ../../

--- a/cmd/chart-repo/Makefile
+++ b/cmd/chart-repo/Makefile
@@ -5,4 +5,4 @@ VERSION ?= $$(git rev-parse HEAD)
 
 docker-build:
 	# We use the context of the root dir
-	docker build --pull --rm -t ${IMAGE_REPO}:${IMAGE_TAG} --build-arg "CODE_VERSION=${VERSION}" -f Dockerfile ../../
+	docker build --pull --rm -t ${IMAGE_REPO}:${IMAGE_TAG} --build-arg "VERSION=${VERSION}" -f Dockerfile ../../

--- a/cmd/chart-repo/chart_repo.go
+++ b/cmd/chart-repo/chart_repo.go
@@ -24,7 +24,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:   "chart-repo",
-	Short: "Kubeapps Chart Repository utility",
+	Short: "Monocular Chart Repository utility",
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},

--- a/cmd/chart-repo/chart_repo.go
+++ b/cmd/chart-repo/chart_repo.go
@@ -24,7 +24,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:   "chart-repo",
-	Short: "Monocular Chart Repository utility",
+	Short: "Chart Repository utility",
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},
@@ -46,7 +46,7 @@ func init() {
 		cmd.Flags().String("mongo-database", "charts", "MongoDB database")
 		cmd.Flags().String("mongo-user", "", "MongoDB user")
 		// see version.go
-		cmd.Flags().StringVarP(&application, "application", "", "", "Name of the application using chart-repo")
+		cmd.Flags().StringVarP(&userAgentComment, "user-agent-comment", "", "", "UserAgent comment used during outbound requests")
 		cmd.Flags().Bool("debug", false, "verbose logging")
 	}
 	rootCmd.AddCommand(versionCmd)

--- a/cmd/chart-repo/chart_repo.go
+++ b/cmd/chart-repo/chart_repo.go
@@ -49,4 +49,5 @@ func init() {
 		cmd.Flags().StringVarP(&application, "application", "", "", "Name of the application using chart-repo")
 		cmd.Flags().Bool("debug", false, "verbose logging")
 	}
+	rootCmd.AddCommand(versionCmd)
 }

--- a/cmd/chart-repo/chart_repo.go
+++ b/cmd/chart-repo/chart_repo.go
@@ -45,6 +45,8 @@ func init() {
 		cmd.Flags().String("mongo-url", "localhost", "MongoDB URL (see https://godoc.org/labix.org/v2/mgo#Dial for format)")
 		cmd.Flags().String("mongo-database", "charts", "MongoDB database")
 		cmd.Flags().String("mongo-user", "", "MongoDB user")
+		// see version.go
+		cmd.Flags().StringVarP(&application, "application", "", "", "Name of the application using chart-repo")
 		cmd.Flags().Bool("debug", false, "verbose logging")
 	}
 }

--- a/cmd/chart-repo/utils.go
+++ b/cmd/chart-repo/utils.go
@@ -166,10 +166,12 @@ func fetchRepoIndex(r repo) (*helmrepo.IndexFile, error) {
 		log.WithFields(log.Fields{"url": req.URL.String()}).WithError(err).Error("could not build repo index request")
 		return nil, err
 	}
+
 	req.Header.Set("User-Agent", userAgent)
 	if len(r.AuthorizationHeader) > 0 {
 		req.Header.Set("Authorization", r.AuthorizationHeader)
 	}
+
 	res, err := netClient.Do(req)
 	if res != nil {
 		defer res.Body.Close()

--- a/cmd/chart-repo/utils.go
+++ b/cmd/chart-repo/utils.go
@@ -167,7 +167,7 @@ func fetchRepoIndex(r repo) (*helmrepo.IndexFile, error) {
 		return nil, err
 	}
 
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", userAgent())
 	if len(r.AuthorizationHeader) > 0 {
 		req.Header.Set("Authorization", r.AuthorizationHeader)
 	}
@@ -280,7 +280,7 @@ func fetchAndImportIcon(dbSession datastore.Session, c chart) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", userAgent())
 	if len(c.Repo.AuthorizationHeader) > 0 {
 		req.Header.Set("Authorization", c.Repo.AuthorizationHeader)
 	}
@@ -330,7 +330,7 @@ func fetchAndImportFiles(dbSession datastore.Session, name string, r repo, cv ch
 	if err != nil {
 		return err
 	}
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", userAgent())
 	if len(r.AuthorizationHeader) > 0 {
 		req.Header.Set("Authorization", r.AuthorizationHeader)
 	}

--- a/cmd/chart-repo/utils_test.go
+++ b/cmd/chart-repo/utils_test.go
@@ -205,16 +205,22 @@ func Test_fetchRepoIndex(t *testing.T) {
 
 func Test_fetchRepoIndexUserAgent(t *testing.T) {
 	tests := []struct {
-		name      string
-		userAgent string
+		name              string
+		version           string
+		expectedUserAgent string
 	}{
-		{"default user agent", "chart-repo/devel"},
+		{"default user agent", "", "chart-repo/devel"},
+		{"custom version", "1.0", "chart-repo/1.0"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.version != "" {
+				version = tt.version
+			}
+
 			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-				assert.Equal(t, tt.userAgent, req.Header.Get("User-Agent"), "expected user agent")
+				assert.Equal(t, tt.expectedUserAgent, req.Header.Get("User-Agent"), "expected user agent")
 				rw.Write([]byte(validRepoIndexYAML))
 			}))
 			// Close the server when test finishes

--- a/cmd/chart-repo/utils_test.go
+++ b/cmd/chart-repo/utils_test.go
@@ -207,7 +207,7 @@ func Test_fetchRepoIndexUserAgent(t *testing.T) {
 	tests := []struct {
 		name              string
 		version           string
-		application       string
+		userAgentComment  string
 		expectedUserAgent string
 	}{
 		{"default user agent", "", "", "chart-repo/devel"},
@@ -222,8 +222,8 @@ func Test_fetchRepoIndexUserAgent(t *testing.T) {
 				version = tt.version
 			}
 
-			if tt.application != "" {
-				application = tt.application
+			if tt.userAgentComment != "" {
+				userAgentComment = tt.userAgentComment
 			}
 
 			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {

--- a/cmd/chart-repo/utils_test.go
+++ b/cmd/chart-repo/utils_test.go
@@ -207,16 +207,23 @@ func Test_fetchRepoIndexUserAgent(t *testing.T) {
 	tests := []struct {
 		name              string
 		version           string
+		application       string
 		expectedUserAgent string
 	}{
-		{"default user agent", "", "chart-repo/devel"},
-		{"custom version", "1.0", "chart-repo/1.0"},
+		{"default user agent", "", "", "chart-repo/devel"},
+		{"custom version no app", "1.0", "", "chart-repo/1.0"},
+		{"custom version and app", "1.0", "monocular/1.2", "chart-repo/1.0 (monocular/1.2)"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Override global variables used to generate the userAgent
 			if tt.version != "" {
 				version = tt.version
+			}
+
+			if tt.application != "" {
+				application = tt.application
 			}
 
 			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {

--- a/cmd/chart-repo/utils_test.go
+++ b/cmd/chart-repo/utils_test.go
@@ -66,10 +66,7 @@ func (h *goodHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	if req.URL.Host == "subpath.test" && req.URL.Path != "/subpath/index.yaml" {
 		w.WriteHeader(500)
 	}
-	// Ensure we're sending the right User-Agent
-	if !strings.Contains(req.Header.Get("User-Agent"), "chart-repo-sync") {
-		w.WriteHeader(500)
-	}
+
 	w.Write([]byte(validRepoIndexYAML))
 	return w.Result(), nil
 }
@@ -204,6 +201,30 @@ func Test_fetchRepoIndex(t *testing.T) {
 		_, err := fetchRepoIndex(repo{URL: "https://my.examplerepo.com"})
 		assert.ExistsErr(t, err, "failed request")
 	})
+}
+
+func Test_fetchRepoIndexUserAgent(t *testing.T) {
+	tests := []struct {
+		name      string
+		userAgent string
+	}{
+		{"default user agent", "chart-repo-sync/devel"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				assert.Equal(t, tt.userAgent, req.Header.Get("User-Agent"), "expected user agent")
+				rw.Write([]byte(validRepoIndexYAML))
+			}))
+			// Close the server when test finishes
+			defer server.Close()
+
+			netClient = server.Client()
+			_, err := fetchRepoIndex(repo{URL: server.URL})
+			assert.NoErr(t, err)
+		})
+	}
 }
 
 func Test_parseRepoIndex(t *testing.T) {

--- a/cmd/chart-repo/utils_test.go
+++ b/cmd/chart-repo/utils_test.go
@@ -208,7 +208,7 @@ func Test_fetchRepoIndexUserAgent(t *testing.T) {
 		name      string
 		userAgent string
 	}{
-		{"default user agent", "chart-repo-sync/devel"},
+		{"default user agent", "chart-repo/devel"},
 	}
 
 	for _, tt := range tests {
@@ -221,6 +221,7 @@ func Test_fetchRepoIndexUserAgent(t *testing.T) {
 			defer server.Close()
 
 			netClient = server.Client()
+
 			_, err := fetchRepoIndex(repo{URL: server.URL})
 			assert.NoErr(t, err)
 		})

--- a/cmd/chart-repo/version.go
+++ b/cmd/chart-repo/version.go
@@ -18,5 +18,5 @@ package main
 
 const (
 	version   = "devel"
-	userAgent = "chart-repo-sync/" + version
+	userAgent = "chart-repo/" + version
 )

--- a/cmd/chart-repo/version.go
+++ b/cmd/chart-repo/version.go
@@ -16,10 +16,23 @@ limitations under the License.
 
 package main
 
+import "fmt"
+
 var (
-	version = "devel"
+	version     = "devel"
+	application = ""
 )
 
+// Returns the user agent to be used during calls to the chart repositories
+// Examples:
+// chart-repo/devel
+// chart-repo/1.0
+// chart-repo/1.0 (monocular v1.0-beta4)
+// More info here https://github.com/kubeapps/kubeapps/issues/767#issuecomment-436835938
 func userAgent() string {
-	return "chart-repo/" + version
+	ua := "chart-repo/" + version
+	if application != "" {
+		ua = fmt.Sprintf("%s (%s)", ua, application)
+	}
+	return ua
 }

--- a/cmd/chart-repo/version.go
+++ b/cmd/chart-repo/version.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package main
 
-const (
-	version   = "devel"
-	userAgent = "chart-repo/" + version
+var (
+	version = "devel"
 )
+
+func userAgent() string {
+	return "chart-repo/" + version
+}

--- a/cmd/chart-repo/version.go
+++ b/cmd/chart-repo/version.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	version     = "devel"
-	application = ""
+	application string
 )
 
 // Returns the user agent to be used during calls to the chart repositories

--- a/cmd/chart-repo/version.go
+++ b/cmd/chart-repo/version.go
@@ -23,8 +23,8 @@ import (
 )
 
 var (
-	version     = "devel"
-	application string
+	version          = "devel"
+	userAgentComment string
 )
 
 // Returns the user agent to be used during calls to the chart repositories
@@ -35,8 +35,8 @@ var (
 // More info here https://github.com/kubeapps/kubeapps/issues/767#issuecomment-436835938
 func userAgent() string {
 	ua := "chart-repo/" + version
-	if application != "" {
-		ua = fmt.Sprintf("%s (%s)", ua, application)
+	if userAgentComment != "" {
+		ua = fmt.Sprintf("%s (%s)", ua, userAgentComment)
 	}
 	return ua
 }

--- a/cmd/chart-repo/version.go
+++ b/cmd/chart-repo/version.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package main
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
 
 var (
 	version     = "devel"
@@ -35,4 +39,12 @@ func userAgent() string {
 		ua = fmt.Sprintf("%s (%s)", ua, application)
 	}
 	return ua
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "returns version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version)
+	},
 }

--- a/cmd/chart-repo/version.go
+++ b/cmd/chart-repo/version.go
@@ -17,6 +17,6 @@ limitations under the License.
 package main
 
 const (
-	version   = "0.3.0"
+	version   = "devel"
 	userAgent = "chart-repo-sync/" + version
 )


### PR DESCRIPTION
* Adds an userAgent function that returns both the baked version and the application that is running it (i.e monocular), this application can be provided via a built-in flag.
* Adds a convenience version command
* Updates Makefile and circle-ci to pass the tagged release. By default unless specified, it will pass the commit sha.

```bash
$ make
docker run -it quay.io/helmpack/chart-repo:latest /chart-repo version
5d7825decbe8b1f1387b2ed916cb01013d214eac
$ make VERSION=1.0
docker run -it quay.io/helmpack/chart-repo:latest /chart-repo version
1.0
```

Next steps would be to update the Monocular chart to pass the new `application` flag.

Refs https://github.com/kubeapps/kubeapps/issues/767