### PR TITLE
Inject user-agent-comment

### DIFF
--- a/chart/monocular/Chart.yaml
+++ b/chart/monocular/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: monocular
 description: Monocular is a search and discovery front end for Helm Charts Repositories.
-version: 1.2.1
+version: 1.2.2
 appVersion: v1.0.1
 home: https://github.com/helm/monocular
 sources:

--- a/chart/monocular/Chart.yaml
+++ b/chart/monocular/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: monocular
 description: Monocular is a search and discovery front end for Helm Charts Repositories.
-version: 1.2.2
+version: 1.2.1
 appVersion: v1.0.1
 home: https://github.com/helm/monocular
 sources:

--- a/chart/monocular/templates/_helpers.tpl
+++ b/chart/monocular/templates/_helpers.tpl
@@ -48,6 +48,7 @@ spec:
     image: {{ template "monocular.image" $global.Values.sync.image }}
     args:
     - sync
+    - --user-agent-comment=monocular/{{ $global.Chart.AppVersion }}
     {{- if and $global.Values.global.mongoUrl (not $global.Values.mongodb.enabled) }}
     - --mongo-url={{ $global.Values.global.mongoUrl }}
     {{- else }}


### PR DESCRIPTION
Injects the monocular version to the chart-repo command to be added in the user-agent


```diff
 multidoc_yamldiff /tmp/before.yaml /tmp/after.yaml

@@ .. @@
       {
        args: [
         "sync",
+        "--user-agent-comment=monocular/v1.0.1",
         "--mongo-url=RELEASE-NAME-mongodb",
         "--mongo-user=root",
         "incubator",
@@ .. @@
       {
        args: [
         "sync",
+        "--user-agent-comment=monocular/v1.0.1",
         "--mongo-url=RELEASE-NAME-mongodb",
         "--mongo-user=root",
         "stable",
@@ .. @@
         {
          args: [
           "sync",
+          "--user-agent-comment=monocular/v1.0.1",
           "--mongo-url=RELEASE-NAME-mongodb",
           "--mongo-user=root",
           "incubator",
@@ .. @@
         {
          args: [
           "sync",
+          "--user-agent-comment=monocular/v1.0.1",
           "--mongo-url=RELEASE-NAME-mongodb",
           "--mongo-user=root",
           "stable",
```

Refs https://github.com/kubeapps/kubeapps/issues/767

Signed-off-by: Miguel Martinez <migmartri@gmail.com>