### PR TITLE
fix sed for updating image tag reference in chart

### DIFF
--- a/scripts/repo-sync.sh
+++ b/scripts/repo-sync.sh
@@ -73,7 +73,7 @@ update_chart_version() {
   CHART_VERSION_NEXT="${CHART_VERSION%.*}.$((${CHART_VERSION##*.}+1))"
   sed -i 's|^version:.*|version: '"$CHART_VERSION_NEXT"'|g' $CHART_PATH/Chart.yaml
   sed -i 's|^appVersion:.*|appVersion: '"$IMAGE_TAG"'|g' $CHART_PATH/Chart.yaml
-  sed -i '/quay.io\/helmpack/{n; s/tag:.*/tag: '"$IMAGE_TAG"'/}' $CHART_PATH/values.yaml
+  sed -i '/helmpack\//{n; s/tag:.*/tag: '"$IMAGE_TAG"'/}' $CHART_PATH/values.yaml
 
   if [ $COMMIT_CHANGES != "false" ]; then
     log "Commiting chart source changes to master branch"


### PR DESCRIPTION
The chart was previous using the repository field incorrectly to
reference the quay.io repo, which was fixed in
https://github.com/helm/monocular/pull/548. This broke this sed script
to update the image tags when releasing a new version, this PR fixes
this.