### PR TITLE
adds ca-certs to chartsvc image to support MongoDB SSL backends

### DIFF
--- a/cmd/chartsvc/Dockerfile
+++ b/cmd/chartsvc/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /go/src/github.com/helm/monocular
 RUN CGO_ENABLED=0 go build -a -installsuffix cgo ./cmd/chartsvc
 
 FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/helm/monocular/chartsvc /chartsvc
 EXPOSE 8080
 CMD ["/chartsvc"]


### PR DESCRIPTION
cc @mattfarina

fixes #564