### PR TITLE
Add option to set MongoDB URL string in a secret

### DIFF
--- a/chart/monocular/README.md
+++ b/chart/monocular/README.md
@@ -108,3 +108,4 @@ $ helm install monocular/monocular -f custom-domains.yaml
 | `ingress.annotations`   | Ingress annotations                      | `{ingress.kubernetes.io/rewrite-target: /, kubernetes.io/ingress.class: nginx}` |
 | `ingress.tls`           | TLS configuration for the Ingress object | `nil`                                                                           |
 | `global.mongoUrl`       | External MongoDB connection URL          | `nil`                                                                           |
+| `global.mongoUrlSecret` | External MongoDB connection URL secret   | `nil`                                                                           |

--- a/chart/monocular/templates/NOTES.txt
+++ b/chart/monocular/templates/NOTES.txt
@@ -9,3 +9,9 @@ Point your Ingress hosts to the address from the output of the above command:
 {{ end -}}
 
 Visit https://github.com/helm/monocular for more information.
+
+{{- if .Values.global.mongoUrlSecret }}
+If you have not already created the external MongoDB connection URL secret:
+
+   kubectl create secret generic {{ .Values.global.mongoUrlSecret }} --namespace {{ .Release.Namespace }} --from-file=./mongo-url-secret
+{{- end }}

--- a/chart/monocular/templates/chartsvc-deployment.yaml
+++ b/chart/monocular/templates/chartsvc-deployment.yaml
@@ -25,17 +25,23 @@ spec:
         command:
         - /chartsvc
         args:
-        {{- if and .Values.global.mongoUrl (not .Values.mongodb.enabled) }}
-        - --mongo-url={{ .Values.global.mongoUrl }}
-        {{- else }}
+        - --mongo-url={{ template "mongodb.url" . }}
+        {{- if .Values.mongodb.enabled }}
         - --mongo-user=root
-        - --mongo-url={{ template "mongodb.fullname" . }}
         env:
         - name: MONGO_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ template "mongodb.fullname" . }}
               key: mongodb-root-password
+        {{- end }}
+        {{- if .Values.global.mongoUrlSecret }}
+        env:
+        - name: MONGO_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.mongoUrlSecret }}
+              key: mongo-url-secret
         {{- end }}
         ports:
         - name: http

--- a/chart/monocular/values.yaml
+++ b/chart/monocular/values.yaml
@@ -148,5 +148,10 @@ mongodb:
 # This must be set if mongodb.enabled is set to false, following the pattern:
 # `mongodb://${MONGODB_USER}:${MONGODB_ROOT_PASSWORD}@${MONGODB_DNS}:${MONGODB_PORT}/${MONGODB_DATABASE}`
 # ref: https://docs.mongodb.com/manual/reference/connection-string/
+# You may set the connection URL in one of two ways:
+# - mongoUrl: store the connection string directly in Helm values
+# - mongoUrlSecret: name of the secret where the connection string is stored,
+#   where the key is "mongo-url-secret". See NOTES.txt.
 global:
   mongoUrl:
+  mongoUrlSecret:


### PR DESCRIPTION
On one hand this could be further simplified by removing the string option, and only allowing the secret option. But that would require a MAJOR version bump (removing an existing option), whereas this only requires MINOR. @prydonius What do you think?

----
Simplify the conditional logic with "mongodb.url" helper definition.

Also remove HTTP_PROXY AND HTTPS_PROXY ENV vars outside the mongodb.enabled
conditional wrapper - I believe that was an unintentional result of two PRs
merging cleanly in close proximity:
- https://github.com/helm/monocular/pull/547
- https://github.com/helm/monocular/pull/554

Signed-off-by: Scott Rigby <scott@r6by.com>