### PR TITLE
fetch list of repos to show in ui from server

### DIFF
--- a/chart/monocular/templates/ui-config.yaml
+++ b/chart/monocular/templates/ui-config.yaml
@@ -19,3 +19,5 @@ data:
         {{- end }}
       }
     };
+  repos.json: |-
+    {"data": {{ toJson .Values.sync.repos }}}

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { ConfigService } from './shared/services/config.service';
 import { MenuService } from './shared/services/menu.service';
 import { SeoService } from './shared/services/seo.service';
 import { AuthService } from './shared/services/auth.service';
+import { ReposService } from './shared/services/repos.service';
 
 /* Components */
 import { AppComponent } from './app.component';
@@ -116,6 +117,7 @@ export function metaFactory(): MetaLoader {
     MenuService,
     SeoService,
     AuthService,
+    ReposService,
   ],
   entryComponents: [
   ],

--- a/frontend/src/app/shared/services/repos.service.ts
+++ b/frontend/src/app/shared/services/repos.service.ts
@@ -38,5 +38,4 @@ export class ReposService {
     console.error(errMsg); // log to console instead
     return Observable.throw(errMsg);
   }
-
 }

--- a/frontend/src/app/shared/services/repos.service.ts
+++ b/frontend/src/app/shared/services/repos.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@angular/core';
+import { RepoAttributes } from '../models/repo';
+import { ConfigService } from './config.service';
+
+import { Observable } from 'rxjs';
+import 'rxjs/add/operator/switchMap';
+import 'rxjs/add/operator/find';
+import 'rxjs/add/operator/map';
+
+import { Http, Response } from '@angular/http';
+
+@Injectable()
+export class ReposService {
+  constructor(
+    private http: Http,
+  ) {
+  }
+
+  /**
+   * Get all repos from the API
+   *
+   * @return {Observable} An observable that will an array with all repos
+   */
+  getRepos(): Observable<RepoAttributes[]> {
+    return this.http.get(`/assets/js/repos.json`)
+                  .map(this.extractData)
+                  .catch(this.handleError);
+  }
+
+  private extractData(res: Response) {
+    let body = res.json();
+    return body.data || { };
+  }
+
+  private handleError (error: any) {
+    let errMsg = (error.json().message) ? error.json().message :
+      error.status ? `${error.status} - ${error.statusText}` : 'Server error';
+    console.error(errMsg); // log to console instead
+    return Observable.throw(errMsg);
+  }
+
+}

--- a/frontend/src/assets/js/repos.json
+++ b/frontend/src/assets/js/repos.json
@@ -1,0 +1,12 @@
+{
+  "data": [
+    {
+      "name": "stable",
+      "url": "https://kubernetes-charts.storage.googleapis.com"
+    },
+    {
+      "name": "incubator",
+      "url": "https://kubernetes-charts-incubator.storage.googleapis.com/"
+    }
+  ]
+}


### PR DESCRIPTION
This adds a new repos.json file that holds the information about
what repositories are being synced, allowing us to remove the current
hack that parses the full charts list response for the list of
repositories. With this, we can once again use the /charts/{repo}
endpoint to fetch charts from a single repo.

closes #572 