### PR TITLE
chart: add namespace arg to ingress NOTES template

### DIFF
--- a/chart/monocular/templates/NOTES.txt
+++ b/chart/monocular/templates/NOTES.txt
@@ -1,7 +1,7 @@
 The Monocular chart sets up an Ingress to serve the API and UI on the same
 domain. You can get the address to access Monocular from this Ingress endpoint:
 
-  $ kubectl get ingress {{ template "fullname" . }}
+  $ kubectl --namespace {{ .Release.Namespace }} get ingress {{ template "fullname" . }}
 
 {{ if ne (join "" .Values.ingress.hosts) "<nil>" -}}
 Point your Ingress hosts to the address from the output of the above command:

--- a/docs/development.md
+++ b/docs/development.md
@@ -32,6 +32,7 @@ single-node cluster for developing Monocular:
 $ minikube start
 $ minikube addons enable ingress
 $ helm init --wait
+$ helm dependency update
 $ helm install --name dev --namespace monocular ./chart/monocular
 ```
 


### PR DESCRIPTION
The command outputted by NOTES.txt on helm install didn't work for me without referencing namespace, this PR addresses that.

Add `helm dependency update` to docs. Without this command I couldn't run the helm install command because I didn't have the dependencies installed.