### PR TITLE
Add security context

### DIFF
--- a/chart/monocular/Chart.yaml
+++ b/chart/monocular/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: monocular
 description: Monocular is a search and discovery front end for Helm Charts Repositories.
-version: 1.2.6
+version: 1.2.7
 appVersion: v1.2.0
 home: https://github.com/helm/monocular
 sources:

--- a/chart/monocular/templates/chartsvc-deployment.yaml
+++ b/chart/monocular/templates/chartsvc-deployment.yaml
@@ -19,6 +19,10 @@ spec:
         app: {{ template "fullname" . }}-chartsvc
         release: {{ .Release.Name }}
     spec:
+{{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
       containers:
       - name: chartsvc
         image: {{ template "monocular.image" .Values.chartsvc.image }}

--- a/chart/monocular/templates/prerender-deployment.yaml
+++ b/chart/monocular/templates/prerender-deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
+{{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
   replicas: {{ .Values.prerender.replicaCount }}
   template:
     metadata:

--- a/chart/monocular/templates/ui-deployment.yaml
+++ b/chart/monocular/templates/ui-deployment.yaml
@@ -13,6 +13,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/ui-config.yaml") . | sha256sum }}
     spec:
+{{- with .Values.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ template "monocular.image" .Values.ui.image }}

--- a/chart/monocular/values.yaml
+++ b/chart/monocular/values.yaml
@@ -151,3 +151,7 @@ mongodb:
 # ref: https://docs.mongodb.com/manual/reference/connection-string/
 global:
   mongoUrl:
+  
+# This parameter will allow to set  securityContext: { "runAsUser": 1001} by example
+# this is usefull to set a user different to 0 (root) It allows to be launch in a Kubernetes with PodSecurityPolicy with a policy set runAsNonRoot
+securityContext:{}

--- a/chart/monocular/values.yaml
+++ b/chart/monocular/values.yaml
@@ -153,5 +153,7 @@ global:
   mongoUrl:
   
 # This parameter will allow to set  securityContext: { "runAsUser": 1001} by example
-# this is usefull to set a user different to 0 (root) It allows to be launch in a Kubernetes with PodSecurityPolicy with a policy set runAsNonRoot
-securityContext:{}
+# this is usefull to set a user different to 0 (root) 
+# It allows to be launch in a Kubernetes with PodSecurityPolicy with a policy set runAsNonRoot
+securityContext: {}
+


### PR DESCRIPTION
This PR allows to set a securityContext to be able to launch monocular in a Kubernetes with a PodSecurityContext set as runAsNonRoot 