### PR TITLE
Add /resolve-repo endpoint to the chartsvc

### DIFF
--- a/cmd/chartsvc/handler.go
+++ b/cmd/chartsvc/handler.go
@@ -214,7 +214,10 @@ func listChartsWithFilters(w http.ResponseWriter, req *http.Request, params Para
 		"name": 1, "repo": 1,
 		"chartversions": bson.M{"$slice": 1},
 	}).All(&charts); err != nil {
-		log.WithError(err).Errorf("could not find the given chart with id %s", params["chartName"])
+		log.WithError(err).Errorf(
+			"could not find charts with the given name %s, version %s and appversion %s",
+			params["chartName"], req.FormValue("version"), req.FormValue("appversion"),
+		)
 		// continue to return empty list
 	}
 

--- a/cmd/chartsvc/handler.go
+++ b/cmd/chartsvc/handler.go
@@ -17,14 +17,18 @@ limitations under the License.
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"reflect"
 
 	"github.com/globalsign/mgo/bson"
 	"github.com/gorilla/mux"
 	"github.com/helm/monocular/cmd/chartsvc/models"
 	"github.com/kubeapps/common/response"
 	log "github.com/sirupsen/logrus"
+	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
 // Params a key-value map of path params
@@ -198,6 +202,90 @@ func getChartVersionValues(w http.ResponseWriter, req *http.Request, params Para
 	}
 
 	w.Write([]byte(files.Values))
+}
+
+func isChartContained(chartData *models.Chart, chartMetadata *chart.Metadata) bool {
+	eq := true
+	// Compare simple fields
+	if chartData.Description != chartMetadata.Description ||
+		chartData.Home != chartMetadata.Home ||
+		chartData.Icon != chartMetadata.Icon {
+		eq = false
+	}
+	// Compare array of key words (but it may be empty)
+	if len(chartData.Keywords) > 0 && len(chartMetadata.Keywords) > 0 {
+		if !reflect.DeepEqual(chartData.Keywords, chartMetadata.Keywords) {
+			eq = false
+		}
+	}
+	// Compare array of maintainers (but it may be empty)
+	if len(chartData.Maintainers) > 0 && len(chartMetadata.Maintainers) > 0 {
+		// Maintainers format is different (pointers versus structs)
+		c2MaintainerArray := []chart.Maintainer{}
+		for _, m := range chartMetadata.Maintainers {
+			c2MaintainerArray = append(c2MaintainerArray, *m)
+		}
+		if !reflect.DeepEqual(chartData.Maintainers, c2MaintainerArray) {
+			eq = false
+		}
+	}
+	if eq {
+		// Charts matches, look if the version exists
+		for _, v := range chartData.ChartVersions {
+			if v.Version == chartMetadata.Version && v.AppVersion == chartMetadata.AppVersion {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// resolveRepo returns the repo that contains the given chart and the latest version found
+func resolveRepo(w http.ResponseWriter, req *http.Request) {
+	db, closer := dbSession.DB()
+	defer closer()
+
+	metadataBytes, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		errStr := fmt.Sprintf("could not read body %v", err)
+		log.WithError(err).Errorf(errStr)
+		response.NewErrorResponse(http.StatusUnprocessableEntity, errStr).Write(w)
+		return
+	}
+	chartMetadata := &chart.Metadata{}
+	err = json.Unmarshal(metadataBytes, chartMetadata)
+	if err != nil {
+		errStr := fmt.Sprintf("could not read body %v", err)
+		log.WithError(err).Errorf(errStr)
+		response.NewErrorResponse(http.StatusUnprocessableEntity, errStr).Write(w)
+		return
+	}
+
+	var charts []*models.Chart
+	if err := db.C(chartCollection).Find(bson.M{"name": chartMetadata.Name}).All(&charts); err != nil {
+		log.WithError(err).Errorf("could not find the given chart with id %s", chartMetadata.Name)
+		// continue to return empty list
+	}
+
+	latest := []models.ChartLatest{}
+	for _, c := range charts {
+		if isChartContained(c, chartMetadata) {
+			// We rely that versions are stored in order (newer first) to return the latest
+			latest = append(latest, models.ChartLatest{
+				Chart:  c.Name,
+				Latest: c.ChartVersions[0].Version,
+				Repo:   c.Repo.Name,
+			})
+		}
+	}
+
+	latestRaw, err := json.Marshal(latest)
+	if err != nil {
+		log.WithError(err).Errorf("could not render result %v", err)
+		response.NewErrorResponse(http.StatusInternalServerError, "could render result").Write(w)
+		return
+	}
+	w.Write(latestRaw)
 }
 
 func newChartResponse(c *models.Chart) *apiResponse {

--- a/cmd/chartsvc/handler_test.go
+++ b/cmd/chartsvc/handler_test.go
@@ -709,25 +709,22 @@ func Test_findLatestChart(t *testing.T) {
 	t.Run("returns mocked chart", func(t *testing.T) {
 		var m mock.Mock
 		dbSession = mockstore.NewMockSession(&m)
-
-		charts := []*models.Chart{
-			&models.Chart{
-				Name: "foo",
-				Repo: models.Repo{Name: "bar"},
-				ChartVersions: []models.ChartVersion{
-					models.ChartVersion{Version: "1.0.0", AppVersion: "0.1.0"},
-					models.ChartVersion{Version: "0.0.1", AppVersion: "0.1.0"},
-				},
+		chart := &models.Chart{
+			Name: "foo",
+			Repo: models.Repo{Name: "bar"},
+			ChartVersions: []models.ChartVersion{
+				models.ChartVersion{Version: "1.0.0", AppVersion: "0.1.0"},
+				models.ChartVersion{Version: "0.0.1", AppVersion: "0.1.0"},
 			},
 		}
+		charts := []*models.Chart{chart}
 		m.On("All", &chartsList).Run(func(args mock.Arguments) {
 			*args.Get(0).(*[]*models.Chart) = charts
 		})
 
-		expectedLatest := []models.ChartLatest{{Name: "foo", LatestVersion: "1.0.0", RepositoryName: "bar"}}
 		latest := findLatestChart("foo", "1.0.0", "0.1.0")
-		if !reflect.DeepEqual(latest, expectedLatest) {
-			t.Errorf("Expecting %v, received %v", expectedLatest, latest)
+		if !reflect.DeepEqual(latest[0], chart) {
+			t.Errorf("Expecting %v, received %v", chart, latest[0])
 		}
 	})
 }

--- a/cmd/chartsvc/handler_test.go
+++ b/cmd/chartsvc/handler_test.go
@@ -21,9 +21,9 @@ import (
 	"encoding/json"
 	"errors"
 	"image/color"
-	"k8s.io/helm/pkg/proto/hapi/chart"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -705,60 +705,29 @@ func Test_getChartVersionValues(t *testing.T) {
 	}
 }
 
-func Test_isChartContained(t *testing.T) {
-	tests := []struct {
-		name          string
-		chart         models.Chart
-		chartMetadata chart.Metadata
-		isContained   bool
-	}{
-		{
-			"chart is contained",
-			models.Chart{Description: "foo", Home: "home", Icon: "icon", Keywords: []string{"foo"}, Maintainers: []chart.Maintainer{chart.Maintainer{Name: "foo"}}, ChartVersions: []models.ChartVersion{models.ChartVersion{Version: "1.0.0", AppVersion: "0.1.0"}}},
-			chart.Metadata{Description: "foo", Home: "home", Icon: "icon", Keywords: []string{"foo"}, Maintainers: []*chart.Maintainer{&chart.Maintainer{Name: "foo"}}, Version: "1.0.0", AppVersion: "0.1.0"},
-			true,
-		},
-		{
-			"description differs",
-			models.Chart{Description: "foo", Home: "home", Icon: "icon", ChartVersions: []models.ChartVersion{models.ChartVersion{Version: "1.0.0", AppVersion: "0.1.0"}}},
-			chart.Metadata{Description: "bar", Home: "home", Icon: "icon", Version: "1.0.0", AppVersion: "0.1.0"},
-			false,
-		},
-		{
-			"Keywords are missing in the metadata",
-			models.Chart{Description: "foo", Home: "home", Icon: "icon", Keywords: []string{"foo"}, ChartVersions: []models.ChartVersion{models.ChartVersion{Version: "1.0.0", AppVersion: "0.1.0"}}},
-			chart.Metadata{Description: "foo", Home: "home", Icon: "icon", Version: "1.0.0", AppVersion: "0.1.0"},
-			true,
-		},
-		{
-			"Keywords differ",
-			models.Chart{Description: "foo", Home: "home", Icon: "icon", Keywords: []string{"foo"}, ChartVersions: []models.ChartVersion{models.ChartVersion{Version: "1.0.0", AppVersion: "0.1.0"}}},
-			chart.Metadata{Description: "foo", Home: "home", Icon: "icon", Keywords: []string{"bar"}, Version: "1.0.0", AppVersion: "0.1.0"},
-			false,
-		},
-		{
-			"Maintainers differ",
-			models.Chart{Description: "foo", Home: "home", Icon: "icon", Keywords: []string{"foo"}, Maintainers: []chart.Maintainer{chart.Maintainer{Name: "foo"}}, ChartVersions: []models.ChartVersion{models.ChartVersion{Version: "1.0.0", AppVersion: "0.1.0"}}},
-			chart.Metadata{Description: "foo", Home: "home", Icon: "icon", Keywords: []string{"bar"}, Maintainers: []*chart.Maintainer{&chart.Maintainer{Name: "bar"}}, Version: "1.0.0", AppVersion: "0.1.0"},
-			false,
-		},
-		{
-			"versions does not match",
-			models.Chart{Description: "foo", Home: "home", Icon: "icon", Keywords: []string{"foo"}, Maintainers: []chart.Maintainer{chart.Maintainer{Name: "foo"}}, ChartVersions: []models.ChartVersion{models.ChartVersion{Version: "1.0.0", AppVersion: "0.1.0"}}},
-			chart.Metadata{Description: "foo", Home: "home", Icon: "icon", Keywords: []string{"foo"}, Maintainers: []*chart.Maintainer{&chart.Maintainer{Name: "foo"}}, Version: "2.0.0", AppVersion: "0.1.0"},
-			false,
-		},
-		{
-			"app versions does not match",
-			models.Chart{Description: "foo", Home: "home", Icon: "icon", Keywords: []string{"foo"}, Maintainers: []chart.Maintainer{chart.Maintainer{Name: "foo"}}, ChartVersions: []models.ChartVersion{models.ChartVersion{Version: "1.0.0", AppVersion: "0.1.0"}}},
-			chart.Metadata{Description: "foo", Home: "home", Icon: "icon", Keywords: []string{"foo"}, Maintainers: []*chart.Maintainer{&chart.Maintainer{Name: "foo"}}, Version: "1.0.0", AppVersion: "0.2.0"},
-			false,
-		},
-	}
+func Test_findLatestChart(t *testing.T) {
+	t.Run("returns mocked chart", func(t *testing.T) {
+		var m mock.Mock
+		dbSession = mockstore.NewMockSession(&m)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, isChartContained(&tt.chart, &tt.chartMetadata), tt.isContained, "Failed to match charts")
+		charts := []*models.Chart{
+			&models.Chart{
+				Name: "foo",
+				Repo: models.Repo{Name: "bar"},
+				ChartVersions: []models.ChartVersion{
+					models.ChartVersion{Version: "1.0.0", AppVersion: "0.1.0"},
+					models.ChartVersion{Version: "0.0.1", AppVersion: "0.1.0"},
+				},
+			},
+		}
+		m.On("All", &chartsList).Run(func(args mock.Arguments) {
+			*args.Get(0).(*[]*models.Chart) = charts
 		})
-	}
+
+		expectedLatest := []models.ChartLatest{{Name: "foo", LatestVersion: "1.0.0", RepositoryName: "bar"}}
+		latest := findLatestChart("foo", "1.0.0", "0.1.0")
+		if !reflect.DeepEqual(latest, expectedLatest) {
+			t.Errorf("Expecting %v, received %v", expectedLatest, latest)
+		}
+	})
 }

--- a/cmd/chartsvc/main.go
+++ b/cmd/chartsvc/main.go
@@ -47,6 +47,7 @@ func setupRoutes() http.Handler {
 	apiv1.Methods("GET").Path("/charts/{repo}/{chartName}").Handler(WithParams(getChart))
 	apiv1.Methods("GET").Path("/charts/{repo}/{chartName}/versions").Handler(WithParams(listChartVersions))
 	apiv1.Methods("GET").Path("/charts/{repo}/{chartName}/versions/{version}").Handler(WithParams(getChartVersion))
+	apiv1.Methods("POST").Path("/charts/resolve-repo").HandlerFunc(resolveRepo)
 	apiv1.Methods("GET").Path("/assets/{repo}/{chartName}/logo-160x160-fit.png").Handler(WithParams(getChartIcon))
 	apiv1.Methods("GET").Path("/assets/{repo}/{chartName}/versions/{version}/README.md").Handler(WithParams(getChartVersionReadme))
 	apiv1.Methods("GET").Path("/assets/{repo}/{chartName}/versions/{version}/values.yaml").Handler(WithParams(getChartVersionValues))

--- a/cmd/chartsvc/main.go
+++ b/cmd/chartsvc/main.go
@@ -47,10 +47,10 @@ func setupRoutes() http.Handler {
 	apiv1.Methods("GET").Path("/charts/{repo}/{chartName}").Handler(WithParams(getChart))
 	apiv1.Methods("GET").Path("/charts/{repo}/{chartName}/versions").Handler(WithParams(listChartVersions))
 	apiv1.Methods("GET").Path("/charts/{repo}/{chartName}/versions/{version}").Handler(WithParams(getChartVersion))
-	apiv1.Methods("POST").Path("/charts/resolve-repo").HandlerFunc(resolveRepo)
 	apiv1.Methods("GET").Path("/assets/{repo}/{chartName}/logo-160x160-fit.png").Handler(WithParams(getChartIcon))
 	apiv1.Methods("GET").Path("/assets/{repo}/{chartName}/versions/{version}/README.md").Handler(WithParams(getChartVersionReadme))
 	apiv1.Methods("GET").Path("/assets/{repo}/{chartName}/versions/{version}/values.yaml").Handler(WithParams(getChartVersionValues))
+	apiv1.Methods("GET").Path("/repos/resolve/{chartName}").Queries("version", "{version}", "appversion", "{appversion}").Handler(WithParams(resolveRepos))
 
 	n := negroni.Classic()
 	n.UseHandler(r)

--- a/cmd/chartsvc/main.go
+++ b/cmd/chartsvc/main.go
@@ -42,7 +42,7 @@ func setupRoutes() http.Handler {
 
 	// Routes
 	apiv1 := r.PathPrefix(pathPrefix).Subrouter()
-	apiv1.Methods("GET").Path("/charts").Queries("name", "{chartName}", "version", "{version}", "appversion", "{appversion}").Handler(WithParams(resolveRepos))
+	apiv1.Methods("GET").Path("/charts").Queries("name", "{chartName}", "version", "{version}", "appversion", "{appversion}").Handler(WithParams(listChartsWithFilters))
 	apiv1.Methods("GET").Path("/charts").HandlerFunc(listCharts)
 	apiv1.Methods("GET").Path("/charts/{repo}").Handler(WithParams(listRepoCharts))
 	apiv1.Methods("GET").Path("/charts/{repo}/{chartName}").Handler(WithParams(getChart))

--- a/cmd/chartsvc/main.go
+++ b/cmd/chartsvc/main.go
@@ -42,6 +42,7 @@ func setupRoutes() http.Handler {
 
 	// Routes
 	apiv1 := r.PathPrefix(pathPrefix).Subrouter()
+	apiv1.Methods("GET").Path("/charts").Queries("name", "{chartName}", "version", "{version}", "appversion", "{appversion}").Handler(WithParams(resolveRepos))
 	apiv1.Methods("GET").Path("/charts").HandlerFunc(listCharts)
 	apiv1.Methods("GET").Path("/charts/{repo}").Handler(WithParams(listRepoCharts))
 	apiv1.Methods("GET").Path("/charts/{repo}/{chartName}").Handler(WithParams(getChart))
@@ -50,7 +51,6 @@ func setupRoutes() http.Handler {
 	apiv1.Methods("GET").Path("/assets/{repo}/{chartName}/logo-160x160-fit.png").Handler(WithParams(getChartIcon))
 	apiv1.Methods("GET").Path("/assets/{repo}/{chartName}/versions/{version}/README.md").Handler(WithParams(getChartVersionReadme))
 	apiv1.Methods("GET").Path("/assets/{repo}/{chartName}/versions/{version}/values.yaml").Handler(WithParams(getChartVersionValues))
-	apiv1.Methods("GET").Path("/repos/resolve/{chartName}").Queries("version", "{version}", "appversion", "{appversion}").Handler(WithParams(resolveRepos))
 
 	n := negroni.Classic()
 	n.UseHandler(r)

--- a/cmd/chartsvc/models/chart.go
+++ b/cmd/chartsvc/models/chart.go
@@ -60,10 +60,3 @@ type ChartFiles struct {
 	Readme string
 	Values string
 }
-
-// ChartLatest express the latest version for a chart in a repo
-type ChartLatest struct {
-	Name           string `json:"name"`
-	LatestVersion  string `json:"latestVersion"`
-	RepositoryName string `json:"repositoryName"`
-}

--- a/cmd/chartsvc/models/chart.go
+++ b/cmd/chartsvc/models/chart.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package models
 
-import "time"
+import (
+	"time"
+
+	"k8s.io/helm/pkg/proto/hapi/chart"
+)
 
 // Repo holds the App repository details
 type Repo struct {
@@ -24,25 +28,19 @@ type Repo struct {
 	URL  string `json:"url"`
 }
 
-// Maintainer holds maintainer details of a chart
-type Maintainer struct {
-	Name  string `json:"name"`
-	Email string `json:"email"`
-}
-
 // Chart is a higher-level representation of a chart package
 type Chart struct {
-	ID            string         `json:"-" bson:"_id"`
-	Name          string         `json:"name"`
-	Repo          Repo           `json:"repo"`
-	Description   string         `json:"description"`
-	Home          string         `json:"home"`
-	Keywords      []string       `json:"keywords"`
-	Maintainers   []Maintainer   `json:"maintainers"`
-	Sources       []string       `json:"sources"`
-	Icon          string         `json:"icon"`
-	RawIcon       []byte         `json:"-" bson:"raw_icon"`
-	ChartVersions []ChartVersion `json:"-"`
+	ID            string             `json:"-" bson:"_id"`
+	Name          string             `json:"name"`
+	Repo          Repo               `json:"repo"`
+	Description   string             `json:"description"`
+	Home          string             `json:"home"`
+	Keywords      []string           `json:"keywords"`
+	Maintainers   []chart.Maintainer `json:"maintainers"`
+	Sources       []string           `json:"sources"`
+	Icon          string             `json:"icon"`
+	RawIcon       []byte             `json:"-" bson:"raw_icon"`
+	ChartVersions []ChartVersion     `json:"-"`
 }
 
 // ChartVersion is a representation of a specific version of a chart
@@ -61,4 +59,11 @@ type ChartFiles struct {
 	ID     string `bson:"_id"`
 	Readme string
 	Values string
+}
+
+// ChartLatest express the latest version for a chart in a repo
+type ChartLatest struct {
+	Chart  string `json:"chart"`
+	Latest string `json:"latest"`
+	Repo   string `json:"repo"`
 }

--- a/cmd/chartsvc/models/chart.go
+++ b/cmd/chartsvc/models/chart.go
@@ -63,7 +63,7 @@ type ChartFiles struct {
 
 // ChartLatest express the latest version for a chart in a repo
 type ChartLatest struct {
-	Chart  string `json:"chart"`
-	Latest string `json:"latest"`
-	Repo   string `json:"repo"`
+	Name           string `json:"name"`
+	LatestVersion  string `json:"latestVersion"`
+	RepositoryName string `json:"repositoryName"`
 }


### PR DESCRIPTION
Ref: https://github.com/kubeapps/kubeapps/issues/588

This PR adds a new endpoint to the chart-svc `/resolve-repo`. This endpoint will receive as a POST some chart metadata (that is contained in the release information) and will return the list of repositories that contains that chart. It also includes the latest version available in that repository.

cc/ @migmartri @prydonius 