### PR TITLE
Use proxy env settings for Transport

### DIFF
--- a/cmd/chart-repo/utils.go
+++ b/cmd/chart-repo/utils.go
@@ -450,6 +450,7 @@ func initNetClient(additionalCA string) (*http.Client, error) {
 	return &http.Client{
 		Timeout: time.Second * defaultTimeoutSeconds,
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				RootCAs: caCertPool,
 			},


### PR DESCRIPTION
Makes chart-repo use proxy environment settings as proposed in https://github.com/kubeapps/kubeapps/issues/696.

Signed-off-by: Ralf Van Dorsselaer <ralfvandorsselaer@gmail.com>