### PR TITLE
chart: Add networkPolicy

### DIFF
--- a/chart/monocular/Chart.yaml
+++ b/chart/monocular/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: monocular
 description: Monocular is a search and discovery front end for Helm Charts Repositories.
-version: 1.3.0
+version: 1.4.0
 appVersion: v1.3.0
 home: https://github.com/helm/monocular
 sources:

--- a/chart/monocular/templates/chartsvc-networkpolicy.yaml
+++ b/chart/monocular/templates/chartsvc-networkpolicy.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "fullname" . }}-chartsvc
+  labels:
+    app: {{ template "fullname" . }}-chartsvc
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "fullname" . }}-chartsvc
+      release: {{ .Release.Name }}
+  ingress:
+  - ports:
+    - port: {{ .Values.chartsvc.service.port }}
+      protocol: TCP
+{{- end }}

--- a/chart/monocular/templates/prerender-networkpolicy.yaml
+++ b/chart/monocular/templates/prerender-networkpolicy.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "fullname" . }}-prerender
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "fullname" . }}-prerender
+  ingress:
+  - ports:
+    - port: {{ .Values.prerender.service.internalPort }}
+      protocol: TCP
+{{- end }}

--- a/chart/monocular/templates/ui-networkpolicy.yaml
+++ b/chart/monocular/templates/ui-networkpolicy.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "fullname" . }}-ui
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "fullname" . }}-ui
+  ingress:
+  - ports:
+    - port: {{ .Values.ui.service.internalPort }}
+      protocol: TCP
+{{- end }}

--- a/chart/monocular/values.yaml
+++ b/chart/monocular/values.yaml
@@ -159,3 +159,8 @@ global:
 # It allows to be launch in a Kubernetes with PodSecurityPolicy with a policy set runAsNonRoot
 securityContext: {}
 
+# Installs networkPolicy for the services. This will allow communication betweeen the services in
+# environments where the default policy is deny
+networkPolicy:
+  enabled: false
+


### PR DESCRIPTION
Add networkPolicy for services. Needed to run monocular in environments where default policy is deny.