### PR TITLE
chartsvc: Add support for pagination

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -149,7 +149,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:dedb317ee5e0ddbec8cbf4837563ffd3490c50e3c24df79f3657a24bb29572e6"
+  digest = "1:450878c69b3a95b75a60e66e69569767d36374f76a8c948057ea09462c108fab"
   name = "github.com/kubeapps/common"
   packages = [
     "datastore",
@@ -157,7 +157,7 @@
     "response",
   ]
   pruneopts = "UT"
-  revision = "80e810ba7d1d481f642349f7a720437f6f54b288"
+  revision = "fcd6537ca4e3f1ecdfa122046bccd009672fc764"
 
 [[projects]]
   digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -149,7 +149,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f26a041c4bcbed68963faad5d47b1fa77a0e4da9724275090a768eedf635d4b9"
+  digest = "1:dedb317ee5e0ddbec8cbf4837563ffd3490c50e3c24df79f3657a24bb29572e6"
   name = "github.com/kubeapps/common"
   packages = [
     "datastore",
@@ -157,7 +157,7 @@
     "response",
   ]
   pruneopts = "UT"
-  revision = "61d8eb6f11b442c6e6928301c7bc58c19860b94e"
+  revision = "80e810ba7d1d481f642349f7a720437f6f54b288"
 
 [[projects]]
   digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
@@ -384,6 +384,7 @@
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",
     "github.com/urfave/negroni",
+    "k8s.io/helm/pkg/proto/hapi/chart",
     "k8s.io/helm/pkg/repo",
   ]
   solver-name = "gps-cdcl"

--- a/cmd/chartsvc/handler.go
+++ b/cmd/chartsvc/handler.go
@@ -67,8 +67,9 @@ type meta struct {
 	TotalPages int `json:"totalPages"`
 }
 
+// count is used to parse the result of a $count operation in the database
 type count struct {
-	Count int `json:"count"`
+	Count int
 }
 
 // getPageNumberAndSize extracts the page number and size of a request. Default (1, 0) if not set

--- a/cmd/chartsvc/handler_test.go
+++ b/cmd/chartsvc/handler_test.go
@@ -35,6 +35,7 @@ import (
 
 type bodyAPIListResponse struct {
 	Data *apiListResponse `json:"data"`
+	Meta meta             `json:"meta,omitempty"`
 }
 
 type bodyAPIResponse struct {
@@ -229,16 +230,81 @@ func Test_newChartVersionListResponse(t *testing.T) {
 func Test_listCharts(t *testing.T) {
 	tests := []struct {
 		name   string
-		charts []*models.Chart
+		query  string
+		store  []*models.Chart
+		result []*models.Chart
+		meta   meta
 	}{
-		{"no charts", []*models.Chart{}},
-		{"one chart", []*models.Chart{
+		{"no charts", "", []*models.Chart{}, []*models.Chart{}, meta{1}},
+		{"one chart", "", []*models.Chart{
 			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-		}},
-		{"two charts", []*models.Chart{
+		}, []*models.Chart{
+			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+		}, meta{1}},
+		{"two charts", "", []*models.Chart{
 			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
 			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
-		}},
+		}, []*models.Chart{
+			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
+		}, meta{1}},
+		// Pagination tests
+		{"four charts with pagination", "?page=2&size=2", []*models.Chart{
+			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		}, []*models.Chart{
+			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		}, meta{2}},
+		{"last page with charts", "?page=2&size=3", []*models.Chart{
+			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		}, []*models.Chart{
+			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		}, meta{2}},
+		{"bigger size than charts", "?page=1&size=10", []*models.Chart{
+			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		}, []*models.Chart{
+			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		}, meta{1}},
+		{"page bigger than existing, returns last one", "?page=10&size=3", []*models.Chart{
+			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		}, []*models.Chart{
+			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		}, meta{2}},
+		{"negative page, defaults to first", "?page=-1&size=2", []*models.Chart{
+			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		}, []*models.Chart{
+			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+		}, meta{2}},
+		{"negative size, defaults to unlimited", "?page=1&size=-2", []*models.Chart{
+			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		}, []*models.Chart{
+			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		}, meta{1}},
 	}
 
 	for _, tt := range tests {
@@ -247,11 +313,11 @@ func Test_listCharts(t *testing.T) {
 			dbSession = mockstore.NewMockSession(&m)
 
 			m.On("All", &chartsList).Run(func(args mock.Arguments) {
-				*args.Get(0).(*[]*models.Chart) = tt.charts
+				*args.Get(0).(*[]*models.Chart) = tt.store
 			})
 
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", "/charts", nil)
+			req := httptest.NewRequest("GET", "/charts"+tt.query, nil)
 			listCharts(w, req)
 
 			m.AssertExpectations(t)
@@ -263,13 +329,14 @@ func Test_listCharts(t *testing.T) {
 				t.Fatal("chart list shouldn't be null")
 			}
 			data := *b.Data
-			assert.Len(t, data, len(tt.charts))
+			assert.Len(t, data, len(tt.result))
 			for i, resp := range data {
-				assert.Equal(t, resp.ID, tt.charts[i].ID, "chart id in the response should be the same")
+				assert.Equal(t, resp.ID, tt.result[i].ID, "chart id in the response should be the same")
 				assert.Equal(t, resp.Type, "chart", "response type is chart")
-				assert.Equal(t, resp.Links.(map[string]interface{})["self"], pathPrefix+"/charts/"+tt.charts[i].ID, "self link should be the same")
-				assert.Equal(t, resp.Relationships["latestChartVersion"].Data.(map[string]interface{})["version"], tt.charts[i].ChartVersions[0].Version, "latestChartVersion should match version at index 0")
+				assert.Equal(t, resp.Links.(map[string]interface{})["self"], pathPrefix+"/charts/"+tt.result[i].ID, "self link should be the same")
+				assert.Equal(t, resp.Relationships["latestChartVersion"].Data.(map[string]interface{})["version"], tt.result[i].ChartVersions[0].Version, "latestChartVersion should match version at index 0")
 			}
+			assert.Equal(t, b.Meta, tt.meta, "response meta should be the same")
 		})
 	}
 }
@@ -278,16 +345,33 @@ func Test_listRepoCharts(t *testing.T) {
 	tests := []struct {
 		name   string
 		repo   string
-		charts []*models.Chart
+		query  string
+		store  []*models.Chart
+		result []*models.Chart
+		meta   meta
 	}{
-		{"repo has no charts", "my-repo", []*models.Chart{}},
-		{"repo has one chart", "my-repo", []*models.Chart{
+		{"repo has no charts", "my-repo", "", []*models.Chart{}, []*models.Chart{}, meta{1}},
+		{"repo has one chart", "my-repo", "", []*models.Chart{
 			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-		}},
-		{"repo has many charts", "my-repo", []*models.Chart{
+		}, []*models.Chart{
+			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+		}, meta{1}},
+		{"repo has many charts", "my-repo", "", []*models.Chart{
 			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
 			{ID: "my-repo/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
-		}},
+		}, []*models.Chart{
+			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{ID: "my-repo/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
+		}, meta{1}},
+		{"repo has many charts with pagination", "my-repo", "?page=2&size=2", []*models.Chart{
+			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
+			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
+			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		}, []*models.Chart{
+			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
+			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
+		}, meta{2}},
 	}
 
 	for _, tt := range tests {
@@ -296,11 +380,11 @@ func Test_listRepoCharts(t *testing.T) {
 			dbSession = mockstore.NewMockSession(&m)
 
 			m.On("All", &chartsList).Run(func(args mock.Arguments) {
-				*args.Get(0).(*[]*models.Chart) = tt.charts
+				*args.Get(0).(*[]*models.Chart) = tt.store
 			})
 
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", "/charts/"+tt.repo, nil)
+			req := httptest.NewRequest("GET", "/charts/"+tt.repo+tt.query, nil)
 			params := Params{
 				"repo": "my-repo",
 			}
@@ -313,12 +397,13 @@ func Test_listRepoCharts(t *testing.T) {
 			var b bodyAPIListResponse
 			json.NewDecoder(w.Body).Decode(&b)
 			data := *b.Data
-			assert.Len(t, data, len(tt.charts))
+			assert.Len(t, data, len(tt.result))
 			for i, resp := range data {
-				assert.Equal(t, resp.ID, tt.charts[i].ID, "chart id in the response should be the same")
+				assert.Equal(t, resp.ID, tt.result[i].ID, "chart id in the response should be the same")
 				assert.Equal(t, resp.Type, "chart", "response type is chart")
-				assert.Equal(t, resp.Relationships["latestChartVersion"].Data.(map[string]interface{})["version"], tt.charts[i].ChartVersions[0].Version, "latestChartVersion should match version at index 0")
+				assert.Equal(t, resp.Relationships["latestChartVersion"].Data.(map[string]interface{})["version"], tt.result[i].ChartVersions[0].Version, "latestChartVersion should match version at index 0")
 			}
+			assert.Equal(t, b.Meta, tt.meta, "response meta should be the same")
 		})
 	}
 }

--- a/cmd/chartsvc/handler_test.go
+++ b/cmd/chartsvc/handler_test.go
@@ -218,88 +218,24 @@ func Test_listCharts(t *testing.T) {
 	tests := []struct {
 		name   string
 		query  string
-		store  []*models.Chart
-		result []*models.Chart
+		charts []*models.Chart
 		meta   meta
 	}{
-		{"no charts", "", []*models.Chart{}, []*models.Chart{}, meta{1}},
+		{"no charts", "", []*models.Chart{}, meta{1}},
 		{"one chart", "", []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-		}, []*models.Chart{
 			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
 		}, meta{1}},
 		{"two charts", "", []*models.Chart{
 			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
 			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
-		}, []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
 		}, meta{1}},
 		// Pagination tests
-		{"four charts with pagination", "?page=2&size=2", []*models.Chart{
+		{"four charts with pagination", "?size=2", []*models.Chart{
 			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
 			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
-		}, []*models.Chart{
 			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
 			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
 		}, meta{2}},
-		{"last page with charts", "?page=2&size=3", []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
-		}, []*models.Chart{
-			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
-		}, meta{2}},
-		{"bigger size than charts", "?page=1&size=10", []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
-		}, []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
-		}, meta{1}},
-		{"page bigger than existing, returns last one", "?page=10&size=3", []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
-		}, []*models.Chart{
-			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
-		}, meta{2}},
-		{"negative page, defaults to first", "?page=-1&size=2", []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
-		}, []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-		}, meta{2}},
-		{"negative size, defaults to unlimited", "?page=1&size=-2", []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
-		}, []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
-		}, meta{1}},
-		{"ignore duplicated charts", "?page=1&size=2", []*models.Chart{
-			{ID: "bitnami/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-		}, []*models.Chart{
-			{ID: "bitnami/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-		}, meta{1}},
 	}
 
 	for _, tt := range tests {
@@ -308,8 +244,11 @@ func Test_listCharts(t *testing.T) {
 			dbSession = mockstore.NewMockSession(&m)
 
 			m.On("All", &chartsList).Run(func(args mock.Arguments) {
-				*args.Get(0).(*[]*models.Chart) = tt.store
+				*args.Get(0).(*[]*models.Chart) = tt.charts
 			})
+			if tt.query != "" {
+				m.On("Count").Return(len(tt.charts))
+			}
 
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest("GET", "/charts"+tt.query, nil)
@@ -324,12 +263,12 @@ func Test_listCharts(t *testing.T) {
 				t.Fatal("chart list shouldn't be null")
 			}
 			data := *b.Data
-			assert.Len(t, data, len(tt.result))
+			assert.Len(t, data, len(tt.charts))
 			for i, resp := range data {
-				assert.Equal(t, resp.ID, tt.result[i].ID, "chart id in the response should be the same")
+				assert.Equal(t, resp.ID, tt.charts[i].ID, "chart id in the response should be the same")
 				assert.Equal(t, resp.Type, "chart", "response type is chart")
-				assert.Equal(t, resp.Links.(map[string]interface{})["self"], pathPrefix+"/charts/"+tt.result[i].ID, "self link should be the same")
-				assert.Equal(t, resp.Relationships["latestChartVersion"].Data.(map[string]interface{})["version"], tt.result[i].ChartVersions[0].Version, "latestChartVersion should match version at index 0")
+				assert.Equal(t, resp.Links.(map[string]interface{})["self"], pathPrefix+"/charts/"+tt.charts[i].ID, "self link should be the same")
+				assert.Equal(t, resp.Relationships["latestChartVersion"].Data.(map[string]interface{})["version"], tt.charts[i].ChartVersions[0].Version, "latestChartVersion should match version at index 0")
 			}
 			assert.Equal(t, b.Meta, tt.meta, "response meta should be the same")
 		})
@@ -341,29 +280,20 @@ func Test_listRepoCharts(t *testing.T) {
 		name   string
 		repo   string
 		query  string
-		store  []*models.Chart
-		result []*models.Chart
+		charts []*models.Chart
 		meta   meta
 	}{
-		{"repo has no charts", "my-repo", "", []*models.Chart{}, []*models.Chart{}, meta{1}},
+		{"repo has no charts", "my-repo", "", []*models.Chart{}, meta{1}},
 		{"repo has one chart", "my-repo", "", []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-		}, []*models.Chart{
 			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
 		}, meta{1}},
 		{"repo has many charts", "my-repo", "", []*models.Chart{
 			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
 			{ID: "my-repo/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
-		}, []*models.Chart{
-			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
-			{ID: "my-repo/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}, {Version: "1.2.2", Digest: "12345"}}},
 		}, meta{1}},
-		{"repo has many charts with pagination", "my-repo", "?page=2&size=2", []*models.Chart{
+		{"repo has many charts with pagination", "my-repo", "?size=2", []*models.Chart{
 			{ID: "my-repo/my-chart", ChartVersions: []models.ChartVersion{{Version: "0.0.1", Digest: "123"}}},
 			{ID: "stable/dokuwiki", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "1234"}}},
-			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
-			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
-		}, []*models.Chart{
 			{ID: "stable/drupal", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "12345"}}},
 			{ID: "stable/wordpress", ChartVersions: []models.ChartVersion{{Version: "1.2.3", Digest: "123456"}}},
 		}, meta{2}},
@@ -375,8 +305,11 @@ func Test_listRepoCharts(t *testing.T) {
 			dbSession = mockstore.NewMockSession(&m)
 
 			m.On("All", &chartsList).Run(func(args mock.Arguments) {
-				*args.Get(0).(*[]*models.Chart) = tt.store
+				*args.Get(0).(*[]*models.Chart) = tt.charts
 			})
+			if tt.query != "" {
+				m.On("Count").Return(len(tt.charts))
+			}
 
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest("GET", "/charts/"+tt.repo+tt.query, nil)
@@ -392,11 +325,11 @@ func Test_listRepoCharts(t *testing.T) {
 			var b bodyAPIListResponse
 			json.NewDecoder(w.Body).Decode(&b)
 			data := *b.Data
-			assert.Len(t, data, len(tt.result))
+			assert.Len(t, data, len(tt.charts))
 			for i, resp := range data {
-				assert.Equal(t, resp.ID, tt.result[i].ID, "chart id in the response should be the same")
+				assert.Equal(t, resp.ID, tt.charts[i].ID, "chart id in the response should be the same")
 				assert.Equal(t, resp.Type, "chart", "response type is chart")
-				assert.Equal(t, resp.Relationships["latestChartVersion"].Data.(map[string]interface{})["version"], tt.result[i].ChartVersions[0].Version, "latestChartVersion should match version at index 0")
+				assert.Equal(t, resp.Relationships["latestChartVersion"].Data.(map[string]interface{})["version"], tt.charts[i].ChartVersions[0].Version, "latestChartVersion should match version at index 0")
 			}
 			assert.Equal(t, b.Meta, tt.meta, "response meta should be the same")
 		})

--- a/cmd/chartsvc/handler_test.go
+++ b/cmd/chartsvc/handler_test.go
@@ -43,6 +43,7 @@ type bodyAPIResponse struct {
 }
 
 var chartsList []*models.Chart
+var cc count
 
 const testChartReadme = "# Quickstart\n\n```bash\nhelm install my-repo/my-chart\n```"
 const testChartValues = "image:\n  registry: docker.io\n  repository: my-repo/my-chart\n  tag: 0.1.0"
@@ -247,7 +248,9 @@ func Test_listCharts(t *testing.T) {
 				*args.Get(0).(*[]*models.Chart) = tt.charts
 			})
 			if tt.query != "" {
-				m.On("Count").Return(len(tt.charts))
+				m.On("One", &cc).Run(func(args mock.Arguments) {
+					*args.Get(0).(*count) = count{len(tt.charts)}
+				})
 			}
 
 			w := httptest.NewRecorder()
@@ -308,7 +311,9 @@ func Test_listRepoCharts(t *testing.T) {
 				*args.Get(0).(*[]*models.Chart) = tt.charts
 			})
 			if tt.query != "" {
-				m.On("Count").Return(len(tt.charts))
+				m.On("One", &cc).Run(func(args mock.Arguments) {
+					*args.Get(0).(*count) = count{len(tt.charts)}
+				})
 			}
 
 			w := httptest.NewRecorder()

--- a/vendor/github.com/kubeapps/common/datastore/datastore.go
+++ b/vendor/github.com/kubeapps/common/datastore/datastore.go
@@ -48,6 +48,7 @@ type Database interface {
 // Collection is an interface for accessing a MongoDB collection
 type Collection interface {
 	Bulk() Bulk
+	Pipe(pipeline interface{}) Pipe
 	Find(query interface{}) Query
 	FindId(id interface{}) Query
 	Count() (n int, err error)
@@ -72,6 +73,12 @@ type Query interface {
 	One(result interface{}) error
 	Sort(fields ...string) Query
 	Select(selector interface{}) Query
+}
+
+// Pipe is an interface for MongoDB aggregation
+type Pipe interface {
+	All(result interface{}) error
+	One(result interface{}) error
 }
 
 // mgoSession wraps an mgo.Session and implements Session
@@ -112,6 +119,10 @@ func (c *mgoCollection) FindId(id interface{}) Query {
 	return &mgoQuery{c.Collection.FindId(id)}
 }
 
+func (c *mgoCollection) Pipe(pipeline interface{}) Pipe {
+	return &mgoPipe{c.Collection.Pipe(pipeline)}
+}
+
 // mgoQuery wraps an mgo.Query and implements Query
 type mgoQuery struct {
 	*mgo.Query
@@ -123,6 +134,11 @@ func (q *mgoQuery) Sort(fields ...string) Query {
 
 func (q *mgoQuery) Select(selector interface{}) Query {
 	return &mgoQuery{q.Query.Select(selector)}
+}
+
+// mgoPipe wraps an mgo.Pipe and implements Pipe
+type mgoPipe struct {
+	*mgo.Pipe
 }
 
 // NewSession initializes a MongoDB connection to the given host

--- a/vendor/github.com/kubeapps/common/datastore/mockstore/mockstore.go
+++ b/vendor/github.com/kubeapps/common/datastore/mockstore/mockstore.go
@@ -74,6 +74,10 @@ func (c mockCollection) Count() (int, error) {
 	return 0, nil
 }
 
+func (c mockCollection) Pipe(pipeline interface{}) datastore.Pipe {
+	return mockPipe{c.Mock}
+}
+
 // mockBulk acts as a mock datastore.Bulk
 type mockBulk struct {
 	*mock.Mock
@@ -112,6 +116,21 @@ func (q mockQuery) Sort(fields ...string) datastore.Query {
 
 func (q mockQuery) Select(selector interface{}) datastore.Query {
 	return q
+}
+
+// mockPipe acts as a mock datastore.Pipe
+type mockPipe struct {
+	*mock.Mock
+}
+
+func (p mockPipe) All(result interface{}) error {
+	p.Called(result)
+	return nil
+}
+
+func (p mockPipe) One(result interface{}) error {
+	p.Called(result)
+	return nil
 }
 
 // NewMockSession returns a mocked Session

--- a/vendor/github.com/kubeapps/common/response/response.go
+++ b/vendor/github.com/kubeapps/common/response/response.go
@@ -63,11 +63,17 @@ If resource data is an array of objects, the data key will be an array:
 type DataResponse struct {
 	Code int         `json:"-"`
 	Data interface{} `json:"data"`
+	Meta interface{} `json:"meta,omitempty"`
 }
 
 // NewDataResponse returns a new DataResponse
 func NewDataResponse(resources interface{}) DataResponse {
-	return DataResponse{http.StatusOK, resources}
+	return DataResponse{http.StatusOK, resources, nil}
+}
+
+// NewDataResponseWithMeta returns a new DataResponse
+func NewDataResponseWithMeta(resources, meta interface{}) DataResponse {
+	return DataResponse{http.StatusOK, resources, meta}
 }
 
 // WithCode sets the code for the response and returns the DataResponse


### PR DESCRIPTION
Signed-off-by: Andres Martinez Gotor <andres@bitnami.com>

This PR adds support for requesting a certain number of charts (and in consequence, divide the response in pages) for the endpoints `/charts` and `/charts/repo`. 

In case the new parameters (`page` and `size`) are not given, the default behavior is maintained (return all the charts in a single page) to avoid breaking changes.

cc/ @prydonius 