### PR TITLE
Removing emeritus maintainers from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,3 @@
 assignees:
   - migmartri
-  - Angelmmiguel
-  - jackfrancis
-  - technosophos
   - prydonius


### PR DESCRIPTION
Removing @technosophos, @jackfrancis and @Angelmmiguel from OWNERS, as these maintainers have agreed to drop down to emeritus status.