### PR TITLE
Fix chart icon aspect ratio

### DIFF
--- a/frontend/src/app/chart-details/chart-details.component.scss
+++ b/frontend/src/app/chart-details/chart-details.component.scss
@@ -66,7 +66,7 @@ $icon-height: 150px;
       justify-content: center;
 
       img {
-        width: 70%;
+        max-width: 70%;
         max-height: 70%;
       }
     }


### PR DESCRIPTION
## Issue
In the case that a chart icon is taller than it is wide it is forced to be square, ruining its aspect ratio.


## Examples:

![image](https://user-images.githubusercontent.com/15719653/55279222-0597e900-530e-11e9-9dcb-ce10e2651f53.png)
From: https://hub.helm.sh/charts/stable/satisfy


![image](https://user-images.githubusercontent.com/15719653/55279228-0f215100-530e-11e9-851f-b3a2cf987640.png)
From: https://hub.helm.sh/charts/nginx/nginx-ingress


## Fix:
![image](https://user-images.githubusercontent.com/15719653/55279233-16e0f580-530e-11e9-9d66-57150d9a088c.png)

![image](https://user-images.githubusercontent.com/15719653/55279235-1f393080-530e-11e9-847e-b40a9e2560b9.png)
