### PR TITLE
Fix CronJob name too long

### DIFF
--- a/chart/monocular/templates/repo-sync-cronjobs.yaml
+++ b/chart/monocular/templates/repo-sync-cronjobs.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ printf "%s-%s-%s" (include "fullname" $) "sync-scheduled" .name | trunc 52 }}
+  name: {{ printf "%s-%s" (include "fullname" $) "sync-scheduled" | trunc 42 }}-{{ .name | trunc 10 }}
   labels:
     monocular.helm.sh/repo-name: {{ .name }}
     app: {{ template "fullname" $ }}

--- a/chart/monocular/templates/repo-sync-cronjobs.yaml
+++ b/chart/monocular/templates/repo-sync-cronjobs.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ template "fullname" $ }}-sync-scheduled-{{ .name }}
+  name: {{ printf "%s-%s-%s" (include "fullname" $) "sync-scheduled" .name | trunc 52 }}
   labels:
     monocular.helm.sh/repo-name: {{ .name }}
     app: {{ template "fullname" $ }}

--- a/chart/monocular/templates/repo-sync-jobs.yaml
+++ b/chart/monocular/templates/repo-sync-jobs.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "fullname" $ }}-sync-initial-{{ .name }}-{{ randAlphaNum 5 | lower }}
+  name: {{ printf "%s-%s" (include "fullname" $) "sync-initial" | trunc 42 }}-{{ .name | trunc 16 }}-{{ randAlphaNum 5 | lower }}
   labels:
     monocular.helm.sh/repo-name: {{ .name }}
     app: {{ template "fullname" $ }}


### PR DESCRIPTION
fixes: https://github.com/helm/monocular/issues/566

# Changes:
* Cronjob name is now truncated at 52 characters
* Job name is now truncated at 63 characters