### PR TITLE
Correct outdated link on details page

### DIFF
--- a/frontend/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
+++ b/frontend/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
@@ -25,8 +25,8 @@
         </button>
       </div>
       <p class="help-link">
-        <a href="https://github.com/kubernetes/helm/blob/master/docs/quickstart.md"
-         target="_blank" title="How to install Helm">Need Helm?</a>
+        <a href="https://github.com/helm/helm/blob/master/docs/quickstart.md" target="_blank"
+          title="How to install Helm">Need Helm?</a>
       </p>
     </mat-tab>
   </mat-tab-group>


### PR DESCRIPTION
The "Need Helm?" link on the details page, e.g. https://hub.helm.sh/charts/stable/traefik, is still pointing to https://github.com/kubernetes/helm/blob/master/docs/quickstart.md instead of https://github.com/kubernetes/helm/blob/master/docs/quickstart.md

This Pull Requests corrects the link. 