### PR TITLE
[chart-repo] Support case insensitive readme file in charts

### DIFF
--- a/cmd/chart-repo/utils.go
+++ b/cmd/chart-repo/utils.go
@@ -468,7 +468,7 @@ func extractFilesFromTarball(filenames []string, tarf *tar.Reader) (map[string]s
 		}
 
 		for _, f := range filenames {
-			if header.Name == f {
+			if strings.EqualFold(header.Name, f) {
 				var b bytes.Buffer
 				io.Copy(&b, tarf)
 				ret[f] = string(b.Bytes())

--- a/cmd/chart-repo/utils_test.go
+++ b/cmd/chart-repo/utils_test.go
@@ -479,6 +479,7 @@ func Test_extractFilesFromTarball(t *testing.T) {
 		{"file", []tarballFile{{"file.txt", "best file ever"}}, "file.txt", "best file ever"},
 		{"multiple file tarball", []tarballFile{{"file.txt", "best file ever"}, {"file2.txt", "worst file ever"}}, "file2.txt", "worst file ever"},
 		{"file in dir", []tarballFile{{"file.txt", "best file ever"}, {"test/file2.txt", "worst file ever"}}, "test/file2.txt", "worst file ever"},
+		{"filename ignore case", []tarballFile{{"Readme.md", "# readme for chart"}, {"values.yaml", "key: value"}}, "README.md", "# readme for chart"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fix #638. Sometimes the chart creator uses the name 'README.md',
'readme.md' or 'Readme.md' in the chart tarball. This patch adds
support for case insensitive filenames in the chart tarball.
We assume any files in the same folder in the chart tarball won't
have the same file name when case ignored, and it should be true.

Signed-off-by: Jesse Hu <seizethetime@163.com>