### PR TITLE
Fix large gap between rows of chart-list

### DIFF
--- a/frontend/src/app/chart-index/chart-index.component.scss
+++ b/frontend/src/app/chart-index/chart-index.component.scss
@@ -7,8 +7,4 @@
   margin: auto;
   display: flex;
   align-items: center;
-
-  app-chart-list {
-    flex: 1;
-  }
 }

--- a/frontend/src/app/charts/charts.component.scss
+++ b/frontend/src/app/charts/charts.component.scss
@@ -42,8 +42,6 @@ $filters-width: 175px;
       border-left: 1px solid $border-color;
 
       app-chart-list {
-        flex: 1;
-        display: flex;
         padding: 1.5em 0 0 1.5em;
       }
 


### PR DESCRIPTION
Fixes: https://github.com/helm/hub/issues/115

Set a height value on `.chart-list` to fix unnecessary gap between rows of `.chart-items`