### PR TITLE
Update chart resources apiVersion

### DIFF
--- a/chart/monocular/Chart.yaml
+++ b/chart/monocular/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: monocular
 description: Monocular is a search and discovery front end for Helm Charts Repositories.
-version: 1.4.10
+version: 1.4.12
 appVersion: v1.8.3
 home: https://github.com/helm/monocular
 sources:

--- a/chart/monocular/requirements.lock
+++ b/chart/monocular/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
   repository: https://kubernetes-charts.storage.googleapis.com
-  version: 4.6.2
-digest: sha256:ccc841efc96895bd5982021aa2fd5300b99acdcddc1bc144f020572f27990c34
-generated: 2018-10-25T22:57:16.837922292-04:00
+  version: 7.2.10
+digest: sha256:314dea8ef057af9180610aeec4be4491ab6e8779be41076411a93360e92a3f40
+generated: "2019-09-28T21:49:40.948575+01:00"

--- a/chart/monocular/requirements.yaml
+++ b/chart/monocular/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mongodb
-  version: 4.6.2
+  version: 7.2.10
   repository: https://kubernetes-charts.storage.googleapis.com
   condition: mongodb.enabled

--- a/chart/monocular/templates/chartsvc-deployment.yaml
+++ b/chart/monocular/templates/chartsvc-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}-chartsvc

--- a/chart/monocular/templates/prerender-deployment.yaml
+++ b/chart/monocular/templates/prerender-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   replicas: {{ .Values.prerender.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}-prerender
   template:
     metadata:
       labels:

--- a/chart/monocular/templates/prerender-deployment.yaml
+++ b/chart/monocular/templates/prerender-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}-prerender

--- a/chart/monocular/templates/ui-deployment.yaml
+++ b/chart/monocular/templates/ui-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}-ui

--- a/chart/monocular/templates/ui-deployment.yaml
+++ b/chart/monocular/templates/ui-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   replicas: {{ .Values.ui.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}-ui
   template:
     metadata:
       labels:


### PR DESCRIPTION
Fixes: https://github.com/helm/monocular/issues/636

### Issue:
This is a required change to make the chart installable on Kubernetes 1.16.

### Proposed changes:
* Update all `Deployment` resources of the chart to `apps/v1` as required by Kubernetes 1.16
* Update `mongodb` chart dependency. From `4.6.2` -> `7.2.10`.
  * This was required because `mongodb:4.6.2` also used the deprecated `"extensions/v1beta1"` apiVersion.
* Add `spec.selector` as required by the new apiVersion.
  
  > Error: release monocular-dev failed: Deployment.apps "monocular-dev-monocular-ui" is invalid: [spec.selector: Required value, spec.template.metadata.labels: Invalid value: map[string]string{"app":"monocular-dev-monocular-ui"}: `selector` does not match template `labels`]



#### Note: 
I did not increment the `version` of the chart. It looks like this is done via CI?