### PR TITLE
Populate and serve values.schema.json if exists

### DIFF
--- a/cmd/chart-repo/types.go
+++ b/cmd/chart-repo/types.go
@@ -56,6 +56,7 @@ type chartFiles struct {
 	ID     string `bson:"_id"`
 	Readme string
 	Values string
+	Schema string
 	Repo   repo
 	Digest string
 }

--- a/cmd/chart-repo/utils.go
+++ b/cmd/chart-repo/utils.go
@@ -430,7 +430,8 @@ func fetchAndImportFiles(dbSession datastore.Session, name string, r repo, cv ch
 
 	readmeFileName := name + "/README.md"
 	valuesFileName := name + "/values.yaml"
-	filenames := []string{valuesFileName, readmeFileName}
+	schemaFileName := name + "/values.schema.json"
+	filenames := []string{valuesFileName, readmeFileName, schemaFileName}
 
 	files, err := extractFilesFromTarball(filenames, tarf)
 	if err != nil {
@@ -447,6 +448,11 @@ func fetchAndImportFiles(dbSession datastore.Session, name string, r repo, cv ch
 		chartFiles.Values = v
 	} else {
 		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("values.yaml not found")
+	}
+	if v, ok := files[schemaFileName]; ok {
+		chartFiles.Schema = v
+	} else {
+		log.WithFields(log.Fields{"name": name, "version": cv.Version}).Info("values.schema.json not found")
 	}
 
 	// inserts the chart files if not already indexed, or updates the existing

--- a/cmd/chartsvc/handler.go
+++ b/cmd/chartsvc/handler.go
@@ -310,6 +310,21 @@ func getChartVersionValues(w http.ResponseWriter, req *http.Request, params Para
 	w.Write([]byte(files.Values))
 }
 
+// getChartVersionSchema returns the values.schema.json for a given chart
+func getChartVersionSchema(w http.ResponseWriter, req *http.Request, params Params) {
+	db, closer := dbSession.DB()
+	defer closer()
+	var files models.ChartFiles
+	fileID := fmt.Sprintf("%s/%s-%s", params["repo"], params["chartName"], params["version"])
+	if err := db.C(filesCollection).FindId(fileID).One(&files); err != nil {
+		log.WithError(err).Errorf("could not find values.schema.json with id %s", fileID)
+		http.NotFound(w, req)
+		return
+	}
+
+	w.Write([]byte(files.Schema))
+}
+
 // listChartsWithFilters returns the list of repos that contains the given chart and the latest version found
 func listChartsWithFilters(w http.ResponseWriter, req *http.Request, params Params) {
 	db, closer := dbSession.DB()

--- a/cmd/chartsvc/main.go
+++ b/cmd/chartsvc/main.go
@@ -59,6 +59,7 @@ func setupRoutes() http.Handler {
 	apiv1.Methods("GET").Path("/assets/{repo}/{chartName}/logo-160x160-fit.png").Handler(WithParams(getChartIcon))
 	apiv1.Methods("GET").Path("/assets/{repo}/{chartName}/versions/{version}/README.md").Handler(WithParams(getChartVersionReadme))
 	apiv1.Methods("GET").Path("/assets/{repo}/{chartName}/versions/{version}/values.yaml").Handler(WithParams(getChartVersionValues))
+	apiv1.Methods("GET").Path("/assets/{repo}/{chartName}/versions/{version}/values.schema.json").Handler(WithParams(getChartVersionSchema))
 
 	n := negroni.Classic()
 	n.UseHandler(r)

--- a/cmd/chartsvc/models/chart.go
+++ b/cmd/chartsvc/models/chart.go
@@ -53,6 +53,7 @@ type ChartVersion struct {
 	URLs       []string  `json:"urls"`
 	Readme     string    `json:"readme" bson:"-"`
 	Values     string    `json:"values" bson:"-"`
+	Schema     string    `json:"schema" bson:"-"`
 }
 
 // ChartFiles holds the README and values for a given chart version
@@ -60,4 +61,5 @@ type ChartFiles struct {
 	ID     string `bson:"_id"`
 	Readme string
 	Values string
+	Schema string
 }


### PR DESCRIPTION
With Helm v3, it's possible to include a new file in a chart called `values.schema.json`. This file is useful to validate that the given values comply with the expected schema. We can also use this to generate a web form to introduce values.

In this PR we add support to `chartrepo` and `chartsvc` to include this information in MongoDB and serve it.

cc/ @absoludity