### PR TITLE
[GH-646] Incorrect value name for repos in chart README

### DIFF
--- a/chart/monocular/Chart.yaml
+++ b/chart/monocular/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: monocular
 description: Monocular is a search and discovery front end for Helm Charts Repositories.
-version: 1.4.10
+version: 1.4.11
 appVersion: v1.8.3
 home: https://github.com/helm/monocular
 sources:

--- a/chart/monocular/README.md
+++ b/chart/monocular/README.md
@@ -56,7 +56,7 @@ See the [values](values.yaml) for the full list of configurable values.
 
 ### Configuring chart repositories
 
-You can configure the chart repositories you want to see in Monocular with the `api.config.repos` value, for example:
+You can configure the chart repositories you want to see in Monocular with the `sync.repos` value, for example:
 
 ```console
 $ cat > custom-repos.yaml <<EOF


### PR DESCRIPTION
Changed reference value api.config.repos to sync.repos. :)