### PR TITLE
Update quickstart URL to https://helm.sh/docs/using_helm/#quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Click [here](docs/about.md) to learn more about Helm, Charts and Kubernetes.
 You can use the chart in this repository to install Monocular in your cluster.
 
 ### Prerequisites
-- [Helm and Tiller installed](https://github.com/helm/helm/blob/master/docs/quickstart.md)
+- [Helm and Tiller installed](https://helm.sh/docs/using_helm/#quickstart)
 - [Nginx Ingress controller](https://kubeapps.com/charts/stable/nginx-ingress)
   - Install with Helm: `helm install stable/nginx-ingress`
   - **Minikube/Kubeadm**: `helm install stable/nginx-ingress --set controller.hostNetwork=true`

--- a/frontend/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
+++ b/frontend/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
@@ -25,7 +25,7 @@
         </button>
       </div>
       <p class="help-link">
-        <a href="https://github.com/helm/helm/blob/master/docs/quickstart.md" target="_blank"
+        <a href="https://helm.sh/docs/using_helm/#quickstart" target="_blank"
           title="How to install Helm">Need Helm?</a>
       </p>
     </mat-tab>


### PR DESCRIPTION
Was browsing the hub trying to figure out how to get started with v3 when I ran across this broken link to the quick start guide. This PR updates it to what I assume is the correct one on the Helm website.