### PR TITLE
Delete repository from all collections

### DIFF
--- a/cmd/chart-repo/utils.go
+++ b/cmd/chart-repo/utils.go
@@ -212,6 +212,13 @@ func deleteRepo(dbSession datastore.Session, repoName string) error {
 	_, err = db.C(chartFilesCollection).RemoveAll(bson.M{
 		"repo.name": repoName,
 	})
+	if err != nil {
+		return err
+	}
+
+	_, err = db.C(repositoryCollection).RemoveAll(bson.M{
+		"_id": repoName,
+	})
 	return err
 }
 

--- a/cmd/chart-repo/utils_test.go
+++ b/cmd/chart-repo/utils_test.go
@@ -336,6 +336,9 @@ func Test_DeleteRepo(t *testing.T) {
 	m.On("RemoveAll", bson.M{
 		"repo.name": "test",
 	})
+	m.On("RemoveAll", bson.M{
+		"_id": "test",
+	})
 	dbSession := mockstore.NewMockSession(m)
 
 	err := deleteRepo(dbSession, "test")


### PR DESCRIPTION
Fixes: https://github.com/kubeapps/kubeapps/issues/1161

When deleting the repo, we should also delete the document from the `repos` collection.